### PR TITLE
Window fullscreen toggle & saving size

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -68,6 +68,9 @@ void Engine::updateHotkeys() {
 		png::write_image(filename.string(), image.get());
 		std::cout << "saved screenshot as " << filename << std::endl;
 	}
+	if (Events::jpressed(keycode::F11)) {
+		Window::toggleFullscreen();
+	}
 }
 
 void Engine::mainloop() {

--- a/src/files/settings_io.cpp
+++ b/src/files/settings_io.cpp
@@ -12,6 +12,7 @@ using std::string;
 toml::Wrapper create_wrapper(EngineSettings& settings) {
 	toml::Wrapper wrapper;
 	toml::Section& display = wrapper.add("display");
+	display.add("fullscreen", &settings.display.fullscreen);
 	display.add("width", &settings.display.width);
 	display.add("height", &settings.display.height);
 	display.add("samples", &settings.display.samples);

--- a/src/settings.h
+++ b/src/settings.h
@@ -6,6 +6,8 @@
 #include "typedefs.h"
 
 struct DisplaySettings {
+	/* Is window in full screen mode */
+	bool fullscreen = false;
     /* Window width (pixels) */
 	int width = 1280;
 	/* Window height (pixels) */

--- a/src/window/Window.h
+++ b/src/window/Window.h
@@ -11,11 +11,16 @@
 
 class GLFWwindow;
 class ImageData;
+struct DisplaySettings;
+struct GLFWmonitor;
 
 class Window {
 	static GLFWwindow* window;
+	static DisplaySettings* settings;
 	static std::stack<glm::vec4> scissorStack;
 	static glm::vec4 scissorArea;
+
+	static bool tryToMaximize(GLFWwindow* window, GLFWmonitor* monitor);
 public:
 	static uint width;
 	static uint height;
@@ -28,6 +33,8 @@ public:
 	static void setShouldClose(bool flag);
 	static void swapBuffers();
 	static void swapInterval(int interval);
+	static void toggleFullscreen();
+	static bool isFullscreen();
 
 	static void pushScissor(glm::vec4 area);
 	static void popScissor();
@@ -36,6 +43,7 @@ public:
 	static void clear();
 	static void setBgColor(glm::vec3 color);
 	static double time();
+	static DisplaySettings* getSettings();
 
 	static glm::vec2 size() {
 		return glm::vec2(width, height);


### PR DESCRIPTION
Добавил возможность переключения полноэкранного режима (F11) и сохранение размера окна.
Теперь при запуске или переключении полноэкранного режима, если сохраненный размер окна равен или больше размера рабочей зоны экрана, окно будет развернуто во весь экран, в ином случае - отцентрировано