### PR TITLE
Quickfix BLOCK_VOID constant

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -1,7 +1,7 @@
 #ifndef SRC_CONSTANTS_H_
 #define SRC_CONSTANTS_H_
 
-#include <limits.h>
+#include <limits>
 #include "typedefs.h"
 
 const int ENGINE_VERSION_MAJOR = 0;
@@ -15,7 +15,7 @@ const int CHUNK_D = 16;
 const int CHUNK_VOL = (CHUNK_W * CHUNK_H * CHUNK_D);
 
 /* BLOCK_VOID is block id used to mark non-existing voxel (voxel of missing chunk) */
-const blockid_t BLOCK_VOID = UCHAR_MAX;
+const blockid_t BLOCK_VOID = std::numeric_limits<blockid_t>::max();
 
 inline uint vox_index(int x, int y, int z, int w=CHUNK_W, int d=CHUNK_D) {
 	return (y * d + z) * w + x;


### PR DESCRIPTION
Теперь если `blockid_t` является любым _стандартным арифметическим типом_, его максимальное значение будет корректно.