### PR TITLE
Правки в финской локализации

### DIFF
--- a/res/texts/fi_FI.txt
+++ b/res/texts/fi_FI.txt
@@ -12,7 +12,7 @@ error.pack-not-found=Pakettia ei löytynyt!
 menu.New World = Uusi Maailma
 menu.Quit=Poistu
 menu.Continue=Jatka
-menu.Save and Quit to Menu=Tallenna ja Takaisin valikoon
+menu.Save and Quit to Menu=Tallenna ja poistu valikkoon
 menu.missing-content=Puuttuu jotkut lisäosat!
 menu.Controls=Ohjaus
 menu.Back to Main Menu=Takaisin Valikoon
@@ -25,10 +25,10 @@ menu.Create World=Luo Maailma
 world.convert-request=Indeksit vaihdettu! Lataa maailma uudeleen?
 
 # Настройки
-settings.Load Distance=Lataus Alue
-settings.Load Speed=Lataus Nopeus
-settings.Fog Curve=Sumun valaistus
-settings.Backlight=Valaistus
+settings.Load Distance=Latausalue
+settings.Load Speed=Latausnopeus
+settings.Fog Curve=Sumun tiheys
+settings.Backlight=Taustavalo
 settings.V-Sync=Pystytahdistus
 
 settings.FOV=Näkökenttä
@@ -41,8 +41,8 @@ movement.back=Taaksepäin
 movement.left=Vaseemalle
 movement.right=Oikealle
 movement.jump=Hyppy
-movement.sprint=Kiihtyvyys
-movement.crouch=Istu alas
+movement.sprint=Juoksu
+movement.crouch=Hiipiä
 movement.cheat=Huijata
 hud.inventory=Varasto
 player.pick=Ottaa lohko

--- a/res/texts/fi_FI.txt
+++ b/res/texts/fi_FI.txt
@@ -14,6 +14,7 @@ menu.Quit=Poistu
 menu.Continue=Jatka
 menu.Save and Quit to Menu=Tallenna ja poistu valikkoon
 menu.missing-content=Puuttuu jotkut lisäosat!
+menu.Content Error=Sisältövirhe!
 menu.Controls=Ohjaus
 menu.Back to Main Menu=Takaisin Valikoon
 menu.Settings=Asetukset
@@ -23,6 +24,7 @@ menu.Name=Nimi
 menu.Create World=Luo Maailma
 
 world.convert-request=Indeksit vaihdettu! Lataa maailma uudeleen?
+world.delete-confirm=Poistetaanko maailma ikuisesti?
 
 # Настройки
 settings.Load Distance=Latausalue


### PR DESCRIPTION
### Описание изменений:

`Lataus Alue` -> `Latausalue` ([yhdyssana](https://fi.wikipedia.org/wiki/Yhdyssana))
`Kiihtyvyys` -> `Juoksu` (kiihtyvyys - редко используемое финское слово, означающее ускорение (из физики), заменено на более обыденное финнами juoksu - "бег") 
`Istu alas` -> `Hiipiä` (Заменён ошибочный перевод "Istu alas" - садись! на более уместный глагол hiipiä - красться)
`Lataus Nopeus` -> Latausnopeus ([yhdyssana](https://fi.wikipedia.org/wiki/Yhdyssana))
`Valaistus` -> `Taustavalo` (Заменено слово valaistus - освещение, на более подходящее [taustavalo](https://en.wiktionary.org/wiki/taustavalo))
`Sumun valaistus` -> `Sumun tiheys` (Исправлен ошибочный перевод Sumun valaistus - "освещение тумана (???)", на плотность тумана - Sumun tiheys) 