### PR TITLE
Spawn different objects within the level

### DIFF
--- a/src/interfaces/Serializable.h
+++ b/src/interfaces/Serializable.h
@@ -4,12 +4,11 @@
 #include <memory>
 #include "../coders/json.h"
 
-class Serializable
-{
+class Serializable {
 public:
     virtual ~Serializable() { }
     virtual std::unique_ptr<dynamic::Map>  serialize() const = 0;
     virtual void deserialize(dynamic::Map* src) = 0;
 };
 
-#endif
+#endif /* SERIALIZABLE_H */

--- a/src/logic/LevelController.cpp
+++ b/src/logic/LevelController.cpp
@@ -6,6 +6,7 @@
 #include "ChunksController.h"
 
 #include "scripting/scripting.h"
+#include "../objects/Object.h"
 
 LevelController::LevelController(EngineSettings& settings, Level* level) 
     : settings(settings), level(level) {
@@ -24,6 +25,19 @@ void LevelController::update(float delta, bool input, bool pause) {
     level->update();
     chunks->update(settings.chunks.loadSpeed);
     blocks->update(delta);
+
+    // erease null pointers
+    level->objects.remove_if([](Object* obj) { return obj == nullptr; });
+
+    // update all objects that needed
+	for(Object *obj : level->objects)
+	{
+		if(obj) {
+            if(obj->shouldUpdate) {
+                obj->update(delta);
+            }
+		}
+	}
 }
 
 void LevelController::onWorldSave() {

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -202,7 +202,7 @@ void PlayerController::resetKeyboard() {
 }
 
 void PlayerController::updateControls(float delta){
-	player->update(level, input, delta);
+	player->updateInput(level, input, delta);
 }
 
 void PlayerController::updateInteraction(){

--- a/src/objects/Object.h
+++ b/src/objects/Object.h
@@ -15,7 +15,7 @@ public:
     bool shouldUpdate = true;
 
 public:
-    virtual ~Object() { destroyed(); }
+    ~Object() { destroyed(); }
 
 public:
     virtual void spawned() { }

--- a/src/objects/Object.h
+++ b/src/objects/Object.h
@@ -1,0 +1,30 @@
+#ifndef OBJECT_H
+#define OBJECT_H
+
+#include "stdlib.h"
+#include <iostream>
+
+class Level;
+
+class Object {
+private:
+    Level* level;
+
+public:
+    int64_t objectUID;    
+    bool shouldUpdate = true;
+
+public:
+    virtual ~Object() { destroyed(); }
+
+public:
+    virtual void spawned() { }
+    virtual void update(float delta) { }
+    virtual void destroyed() { }
+
+public:
+    Level* getLevel() { return level; }
+    void setLevel(Level* lvl) { level = lvl; }
+};
+
+#endif /* OBJECT_H */

--- a/src/objects/Player.cpp
+++ b/src/objects/Player.cpp
@@ -33,7 +33,7 @@ Player::Player(glm::vec3 position, float speed) :
 Player::~Player() {
 }
 
-void Player::update(
+void Player::updateInput(
 		Level* level,
 		PlayerInput& input, 
 		float delta) {

--- a/src/objects/Player.h
+++ b/src/objects/Player.h
@@ -8,6 +8,7 @@
 #include "../voxels/voxel.h"
 #include "../settings.h"
 #include "../interfaces/Serializable.h"
+#include "../objects/Object.h"
 
 class Camera;
 class Hitbox;
@@ -32,7 +33,7 @@ struct PlayerInput {
     bool flight;
 };
 
-class Player : Serializable {
+class Player : Object, Serializable {
     float speed;
     int chosenSlot;
     glm::vec3 spawnpoint {};
@@ -52,7 +53,7 @@ public:
     ~Player();
 
     void teleport(glm::vec3 position);
-    void update(Level* level, PlayerInput& input, float delta);
+    void updateInput(Level* level, PlayerInput& input, float delta);
 
     void attemptToFindSpawnpoint(Level* level);
 

--- a/src/world/Level.h
+++ b/src/world/Level.h
@@ -5,10 +5,12 @@
 
 #include "../typedefs.h"
 #include "../settings.h"
+#include <list>
 
 class Content;
 class World;
 class Player;
+class Object;
 class Chunks;
 class LevelEvents;
 class Lighting;
@@ -19,6 +21,7 @@ class Level {
 public:
 	std::unique_ptr<World> world;
 	const Content* const content;
+	std::list<Object*> objects;
 	Player* player;
 	Chunks* chunks;
 	ChunksStorage* chunksStorage;
@@ -31,13 +34,15 @@ public:
 
 	Level(World* world, 
 		  const Content* content,
-	      Player* player, 
 	      EngineSettings& settings);
 	~Level();
 
 	void update();
     
     World* getWorld();
+
+	template<class T, typename... Args>
+	T* spawnObjectOfClass(Args&&... args);
 };
 
 #endif /* WORLD_LEVEL_H_ */

--- a/src/world/World.cpp
+++ b/src/world/World.cpp
@@ -62,9 +62,6 @@ void World::write(Level* level) {
     wfile->writePlayer(level->player);
 }
 
-const float DEF_PLAYER_Y = 100.0f;
-const float DEF_PLAYER_SPEED = 4.0f;
-
 Level* World::create(std::string name, 
                      fs::path directory, 
                      uint64_t seed,
@@ -72,8 +69,7 @@ Level* World::create(std::string name,
                      const Content* content,
                      const std::vector<ContentPack>& packs) {
     World* world = new World(name, directory, seed, settings, content, packs);
-    Player* player = new Player(glm::vec3(0, DEF_PLAYER_Y, 0), DEF_PLAYER_SPEED);
-    return new Level(world, content, player, settings);
+    return new Level(world, content, settings);
 }
 
 ContentLUT* World::checkIndices(const fs::path& directory, 
@@ -98,9 +94,8 @@ Level* World::load(fs::path directory,
         throw world_load_error("could not to find world.json");
     }
 
-    Player* player = new Player(glm::vec3(0, DEF_PLAYER_Y, 0), DEF_PLAYER_SPEED);
-    Level* level = new Level(world.get(), content, player, settings);
-    wfile->readPlayer(player);
+    Level* level = new Level(world.get(), content, settings);
+    wfile->readPlayer(level->player);
 
     world.release();
     return level;


### PR DESCRIPTION
В класс Level добавлен метод spawnObjectOfClass<T>(...), создающий объекты наследующие базовый класс Object c методами created, update, destroyed.

Что это даёт: 
1. Возможность создавать объекты наследующие общий принцип поведения, ими могут быть: интерактивные объекты, мобы, лодки, игроки;
2. Возможность спавнить данные объекты в мире без каких-либо ограничений.

Возможные улучшения в будущем:
1. Расширение функциональности класса Object, например: определение положения объекта в пространств
2. Добавить возможность рендерить данные объекты;
3. Подключение скриптинга LUA, чтобы мододелы могли создавать любые объекты со сложным поведением, вплоть до мобов с моделями.
4.  Возможность обращаться к объектам одного класса, например findObjectsOfClass<T>()

Класс Player в данном коммите уже использует данный принцип создания объектов.