### PR TITLE
Fix clang-tidy modernize warnings and clarify static binding in destructors and constructors

### DIFF
--- a/src/audio/AL/ALAudio.cpp
+++ b/src/audio/AL/ALAudio.cpp
@@ -40,7 +40,7 @@ ALStream::ALStream(ALAudio* al, std::shared_ptr<PCMStream> source, bool keepSour
 }
 
 ALStream::~ALStream() {
-    bindSpeaker(0);
+    ALStream::bindSpeaker(0);
     source = nullptr;
 
     while (!unusedBuffers.empty()) {
@@ -203,7 +203,7 @@ ALSpeaker::ALSpeaker(ALAudio* al, uint source, int priority, int channel)
 
 ALSpeaker::~ALSpeaker() {
     if (source) {
-        stop();
+        ALSpeaker::stop();
     }
 }
 

--- a/src/coders/ogg.cpp
+++ b/src/coders/ogg.cpp
@@ -92,7 +92,7 @@ public:
 
     ~OggStream() {
         if (!closed) {
-            close();
+            OggStream::close();
         }
     }
 

--- a/src/coders/xml.hpp
+++ b/src/coders/xml.hpp
@@ -23,18 +23,18 @@ namespace xml {
         std::string name;
         std::string text;
     public:
-        Attribute() {};
+        Attribute() = default;
         Attribute(std::string name, std::string text);
 
-        const std::string& getName() const;
-        const std::string& getText() const;
-        int64_t asInt() const;
-        double asFloat() const;
-        bool asBool() const;
-        glm::vec2 asVec2() const;
-        glm::vec3 asVec3() const;
-        glm::vec4 asVec4() const;
-        glm::vec4 asColor() const;
+        [[nodiscard]] const std::string& getName() const;
+        [[nodiscard]] const std::string& getText() const;
+        [[nodiscard]] int64_t asInt() const;
+        [[nodiscard]] double asFloat() const;
+        [[nodiscard]] bool asBool() const;
+        [[nodiscard]] glm::vec2 asVec2() const;
+        [[nodiscard]] glm::vec3 asVec3() const;
+        [[nodiscard]] glm::vec4 asVec4() const;
+        [[nodiscard]] glm::vec4 asColor() const;
     };
 
     /// @brief XML element class. Text element has tag 'text' and attribute 'text'
@@ -54,13 +54,13 @@ namespace xml {
         void set(std::string name, std::string text);
         
         /// @brief Get element tag
-        const std::string& getTag() const;
+        [[nodiscard]] const std::string& getTag() const;
 
-        inline bool isText() const {
+        [[nodiscard]] inline bool isText() const {
             return getTag() == "#";
         }
 
-        inline const std::string& text() const {
+        [[nodiscard]] inline const std::string& text() const {
             return attr("#").getText();
         }
 
@@ -68,18 +68,18 @@ namespace xml {
         /// @param name attribute name
         /// @throws std::runtime_error if element has no attribute 
         /// @return xmlattribute - {name, value}
-        const xmlattribute attr(const std::string& name) const;
+        [[nodiscard]] const xmlattribute attr(const std::string& name) const;
         
         /// @brief Get attribute by name
         /// @param name attribute name
         /// @param def default value will be returned wrapped in xmlattribute
         /// if element has no attribute 
         /// @return xmlattribute - {name, value} or {name, def} if not found*/
-        const xmlattribute attr(const std::string& name, const std::string& def) const;
+        [[nodiscard]] const xmlattribute attr(const std::string& name, const std::string& def) const;
 
         /// @brief Check if element has attribute
         /// @param name attribute name
-        bool has(const std::string& name) const;
+        [[nodiscard]] bool has(const std::string& name) const;
 
         /// @brief Get sub-element by index
         /// @param index sub-element index
@@ -88,10 +88,10 @@ namespace xml {
         xmlelement sub(size_t index);
 
         /// @brief Get number of sub-elements
-        size_t size() const;
+        [[nodiscard]] size_t size() const;
 
-        const std::vector<xmlelement>& getElements() const;
-        const xmlelements_map& getAttributes() const;
+        [[nodiscard]] const std::vector<xmlelement>& getElements() const;
+        [[nodiscard]] const xmlelements_map& getAttributes() const;
     };
 
     class Document {
@@ -102,10 +102,10 @@ namespace xml {
         Document(std::string version, std::string encoding);
 
         void setRoot(xmlelement element);
-        xmlelement getRoot() const;
+        [[nodiscard]] xmlelement getRoot() const;
 
-        const std::string& getVersion() const;
-        const std::string& getEncoding() const;
+        [[nodiscard]] const std::string& getVersion() const;
+        [[nodiscard]] const std::string& getEncoding() const;
     };
 
     class Parser : BasicParser {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -89,7 +89,7 @@ Engine::Engine(EngineSettings& settings, SettingsHandler& settingsHandler, Engin
     if (ENGINE_DEBUG_BUILD) {
         menus::create_version_label(this);
     }
-    keepAlive(settings.ui.language.observe([=](auto lang) {
+    ObjectsKeeper::keepAlive(settings.ui.language.observe([=](auto lang) {
         setLanguage(lang);
     }, true));
     addWorldGenerators();

--- a/src/frontend/screens/LevelScreen.cpp
+++ b/src/frontend/screens/LevelScreen.cpp
@@ -41,14 +41,14 @@ LevelScreen::LevelScreen(Engine* engine, std::unique_ptr<Level> level)
 
     worldRenderer = std::make_unique<WorldRenderer>(engine, frontend.get(), controller->getPlayer());
     hud = std::make_unique<Hud>(engine, frontend.get(), controller->getPlayer());
-    
-    keepAlive(settings.graphics.backlight.observe([=](bool) {
+
+    ObjectsKeeper::keepAlive(settings.graphics.backlight.observe([=](bool) {
         controller->getLevel()->chunks->saveAndClear();
     }));
-    keepAlive(settings.camera.fov.observe([=](double value) {
+    ObjectsKeeper::keepAlive(settings.camera.fov.observe([=](double value) {
         controller->getPlayer()->camera->setFov(glm::radians(value));
     }));
-    keepAlive(Events::getBinding(BIND_CHUNKS_RELOAD).onactived.add([=](){
+    ObjectsKeeper::keepAlive(Events::getBinding(BIND_CHUNKS_RELOAD).onactived.add([=](){
         controller->getLevel()->chunks->saveAndClear();
     }));
 

--- a/src/graphics/core/Atlas.cpp
+++ b/src/graphics/core/Atlas.cpp
@@ -12,15 +12,14 @@ Atlas::Atlas(
     bool prepare
 ) : texture(nullptr),
     image(std::move(image)),
-    regions(regions) 
+    regions(std::move(regions))
 {        
     if (prepare) {
         this->prepare();
     }
 }
 
-Atlas::~Atlas() {
-}
+Atlas::~Atlas() = default;
 
 void Atlas::prepare() {
     texture = Texture::from(image.get());

--- a/src/graphics/core/Atlas.hpp
+++ b/src/graphics/core/Atlas.hpp
@@ -29,11 +29,11 @@ public:
 
     void prepare();
 
-    bool has(const std::string& name) const;
-    const UVRegion& get(const std::string& name) const;
+    [[nodiscard]] bool has(const std::string& name) const;
+    [[nodiscard]] const UVRegion& get(const std::string& name) const;
 
-    Texture* getTexture() const;
-    ImageData* getImage() const;
+    [[nodiscard]] Texture* getTexture() const;
+    [[nodiscard]] ImageData* getImage() const;
 };
 
 struct atlasentry {
@@ -45,9 +45,9 @@ class AtlasBuilder {
     std::vector<atlasentry> entries;
     std::set<std::string> names;
 public:
-    AtlasBuilder() {}
+    AtlasBuilder() = default;
     void add(std::string name, std::unique_ptr<ImageData> image);
-    bool has(const std::string& name) const;
+    [[nodiscard]] bool has(const std::string& name) const;
     const std::set<std::string>& getNames() { return names; };
 
     /// @brief Build atlas from all added images

--- a/src/graphics/core/Batch2D.cpp
+++ b/src/graphics/core/Batch2D.cpp
@@ -24,8 +24,7 @@ Batch2D::Batch2D(size_t capacity) : capacity(capacity), color(1.0f){
     currentTexture = nullptr;
 }
 
-Batch2D::~Batch2D(){
-}
+Batch2D::~Batch2D()= default;
 
 void Batch2D::setPrimitive(DrawPrimitive primitive) {
     if (primitive == this->primitive) {

--- a/src/graphics/core/Batch2D.hpp
+++ b/src/graphics/core/Batch2D.hpp
@@ -49,7 +49,7 @@ public:
     inline void setColor(glm::vec4 color) {
         this->color = color;
     }
-    inline glm::vec4 getColor() const {
+    [[nodiscard]] glm::vec4 getColor() const {
         return color;
     }
     

--- a/src/graphics/core/Batch3D.cpp
+++ b/src/graphics/core/Batch3D.cpp
@@ -25,8 +25,7 @@ Batch3D::Batch3D(size_t capacity)
     currentTexture = nullptr;
 }
 
-Batch3D::~Batch3D(){
-}
+Batch3D::~Batch3D()= default;
 
 void Batch3D::begin(){
     currentTexture = nullptr;
@@ -168,7 +167,7 @@ void Batch3D::sprite(
 }
 
 inline glm::vec4 do_tint(float value) {
-    return glm::vec4(value, value, value, 1.0f);
+    return {value, value, value, 1.0f};
 }
 
 void Batch3D::xSprite(

--- a/src/graphics/core/Cubemap.hpp
+++ b/src/graphics/core/Cubemap.hpp
@@ -8,8 +8,8 @@ class Cubemap : public Texture {
 public:
     Cubemap(uint width, uint height, ImageFormat format);
 
-    virtual void bind() override;
-    virtual void unbind() override;
+    void bind() override;
+    void unbind() override;
 };
 
 #endif // GRAPHICS_CORE_CUBEMAP_HPP_

--- a/src/graphics/core/DrawContext.hpp
+++ b/src/graphics/core/DrawContext.hpp
@@ -22,9 +22,9 @@ public:
     DrawContext(const DrawContext* parent, const Viewport& viewport, Batch2D* g2d);
     ~DrawContext();
     
-    Batch2D* getBatch2D() const;
-    const Viewport& getViewport() const;
-    DrawContext sub() const;
+    [[nodiscard]] Batch2D* getBatch2D() const;
+    [[nodiscard]] const Viewport& getViewport() const;
+    [[nodiscard]] DrawContext sub() const;
 
     void setViewport(const Viewport& viewport);
     void setFramebuffer(Framebuffer* fbo);

--- a/src/graphics/core/Font.hpp
+++ b/src/graphics/core/Font.hpp
@@ -23,8 +23,8 @@ public:
     Font(std::vector<std::unique_ptr<Texture>> pages, int lineHeight, int yoffset);
     ~Font();
 
-    int getLineHeight() const;
-    int getYOffset() const;
+    [[nodiscard]] int getLineHeight() const;
+    [[nodiscard]] int getYOffset() const;
     
     /// @brief Calculate text width in pixels
     /// @param text selected text
@@ -41,7 +41,7 @@ public:
 
     /// @brief Check if character is visible (non-whitespace)
     /// @param codepoint character unicode codepoint
-    bool isPrintableChar(uint codepoint) const;
+    [[nodiscard]] bool isPrintableChar(uint codepoint) const;
     void draw(Batch2D* batch, std::wstring text, int x, int y);
     void draw(Batch2D* batch, std::wstring text, int x, int y, FontStyle style);
     void draw(Batch2D* batch, std::wstring_view text, int x, int y, FontStyle style);

--- a/src/graphics/core/Framebuffer.hpp
+++ b/src/graphics/core/Framebuffer.hpp
@@ -31,12 +31,12 @@ public:
     void resize(uint width, uint height);
 
     /// @brief Get framebuffer color attachment
-    Texture* getTexture() const;
+    [[nodiscard]] Texture* getTexture() const;
 
     /// @brief Get framebuffer width
-    uint getWidth() const;
+    [[nodiscard]] uint getWidth() const;
     /// @brief Get framebuffer height
-    uint getHeight() const;
+    [[nodiscard]] uint getHeight() const;
 };
 
 #endif // GRAPHICS_CORE_FRAMEBUFFER_HPP_

--- a/src/graphics/core/ImageData.cpp
+++ b/src/graphics/core/ImageData.cpp
@@ -29,7 +29,7 @@ ImageData::~ImageData() {
     switch (format) {
         case ImageFormat::rgb888:
         case ImageFormat::rgba8888:
-            delete[] (ubyte*)data;
+            delete[] static_cast<ubyte *>(data);
             break;
     }
 }
@@ -39,7 +39,7 @@ void ImageData::flipX() {
         case ImageFormat::rgb888:
         case ImageFormat::rgba8888: {
             uint size = (format == ImageFormat::rgba8888) ? 4 : 3;
-            ubyte* pixels = (ubyte*)data;
+            auto pixels = static_cast<ubyte *>(data);
             for (uint y = 0; y < height; y++) {
                 for (uint x = 0; x < width/2; x++) {
                     for (uint c = 0; c < size; c++) {
@@ -61,7 +61,7 @@ void ImageData::flipY() {
         case ImageFormat::rgb888:
         case ImageFormat::rgba8888: {
             uint size = (format == ImageFormat::rgba8888) ? 4 : 3;
-            ubyte* pixels = (ubyte*)data;
+            auto pixels = static_cast<ubyte *>(data);
             for (uint y = 0; y < height/2; y++) {
                 for (uint x = 0; x < width; x++) {
                     for (uint c = 0; c < size; c++) {
@@ -93,13 +93,13 @@ void ImageData::blit(const ImageData* image, int x, int y) {
 }
 
 void ImageData::blitRGB_on_RGBA(const ImageData* image, int x, int y) {
-    ubyte* pixels = static_cast<ubyte*>(data);
-    ubyte* source = static_cast<ubyte*>(image->getData());
+    auto pixels = static_cast<ubyte*>(data);
+    auto source = static_cast<ubyte*>(image->getData());
     uint srcwidth = image->getWidth();
     uint srcheight = image->getHeight();
 
-    for (uint srcy = max(0, -y); (int)srcy < min(srcheight, height-y); srcy++) {
-        for (uint srcx = max(0, -x); (int)srcx < min(srcwidth, width-x); srcx++) {
+    for (uint srcy = max(0, -y); static_cast<int>(srcy) < min(srcheight, height-y); srcy++) {
+        for (uint srcx = max(0, -x); static_cast<int>(srcx) < min(srcwidth, width-x); srcx++) {
             uint dstx = srcx + x;
             uint dsty = srcy + y;
             uint dstidx = (dsty * width + dstx) * 4;
@@ -120,13 +120,13 @@ void ImageData::blitMatchingFormat(const ImageData* image, int x, int y) {
         default:
             throw std::runtime_error("only unsigned byte formats supported");    
     }
-    ubyte* pixels = static_cast<ubyte*>(data);
-    ubyte* source = static_cast<ubyte*>(image->getData());
+    auto pixels = static_cast<ubyte*>(data);
+    auto source = static_cast<ubyte*>(image->getData());
     uint srcwidth = image->getWidth();
     uint srcheight = image->getHeight();
 
-    for (uint srcy = max(0, -y); (int)srcy < min(srcheight, height-y); srcy++) {
-        for (uint srcx = max(0, -x); (int)srcx < min(srcwidth, width-x); srcx++) {
+    for (uint srcy = max(0, -y); static_cast<int>(srcy) < min(srcheight, height-y); srcy++) {
+        for (uint srcx = max(0, -x); static_cast<int>(srcx) < min(srcwidth, width-x); srcx++) {
             uint dstx = srcx + x;
             uint dsty = srcy + y;
             uint dstidx = (dsty * width + dstx) * comps;
@@ -148,13 +148,13 @@ void ImageData::extrude(int x, int y, int w, int h) {
         default:
             throw std::runtime_error("only unsigned byte formats supported");    
     }
-    ubyte* pixels = static_cast<ubyte*>(data);
+    auto pixels = static_cast<ubyte*>(data);
 
     int rx = x + w - 1;
     int ry = y + h - 1;
 
     // top-left pixel
-    if (x > 0 && (uint)x < width && y > 0 && (uint)y < height) {
+    if (x > 0 && static_cast<uint>(x) < width && y > 0 && static_cast<uint>(y) < height) {
         uint srcidx = (y * width + x) * comps;
         uint dstidx = ((y - 1) * width + x - 1) * comps;
         for (uint c = 0; c < comps; c++) {
@@ -163,7 +163,7 @@ void ImageData::extrude(int x, int y, int w, int h) {
     }
     
     // top-right pixel
-    if (rx >= 0 && (uint)rx < width-1 && y > 0 && (uint)y < height) {
+    if (rx >= 0 && static_cast<uint>(rx) < width-1 && y > 0 && static_cast<uint>(y) < height) {
         uint srcidx = (y * width + rx) * comps;
         uint dstidx = ((y - 1) * width + rx + 1) * comps;
         for (uint c = 0; c < comps; c++) {
@@ -172,7 +172,7 @@ void ImageData::extrude(int x, int y, int w, int h) {
     }
 
     // bottom-left pixel
-    if (x > 0 && (uint)x < width && ry >= 0 && (uint)ry < height-1) {
+    if (x > 0 && static_cast<uint>(x) < width && ry >= 0 && static_cast<uint>(ry) < height-1) {
         uint srcidx = (ry * width + x) * comps;
         uint dstidx = ((ry + 1) * width + x - 1) * comps;
         for (uint c = 0; c < comps; c++) {
@@ -181,7 +181,7 @@ void ImageData::extrude(int x, int y, int w, int h) {
     }
     
     // bottom-right pixel
-    if (rx >= 0 && (uint)rx < width-1 && ry >= 0 && (uint)ry < height-1) {
+    if (rx >= 0 && static_cast<uint>(rx) < width-1 && ry >= 0 && static_cast<uint>(ry) < height-1) {
         uint srcidx = (ry * width + rx) * comps;
         uint dstidx = ((ry + 1) * width + rx + 1) * comps;
         for (uint c = 0; c < comps; c++) {
@@ -190,8 +190,8 @@ void ImageData::extrude(int x, int y, int w, int h) {
     }
 
     // left border
-    if (x > 0 && (uint)x < width) {
-        for (uint ey = max(y, 0); (int)ey < y + h; ey++) {
+    if (x > 0 && static_cast<uint>(x) < width) {
+        for (uint ey = max(y, 0); static_cast<int>(ey) < y + h; ey++) {
             uint srcidx = (ey * width + x) * comps;
             uint dstidx = (ey * width + x - 1) * comps;
             for (uint c = 0; c < comps; c++) {
@@ -201,8 +201,8 @@ void ImageData::extrude(int x, int y, int w, int h) {
     }
 
     // top border
-    if (y > 0 && (uint)y < height) {
-        for (uint ex = max(x, 0); (int)ex < x + w; ex++) {
+    if (y > 0 && static_cast<uint>(y) < height) {
+        for (uint ex = max(x, 0); static_cast<int>(ex) < x + w; ex++) {
             uint srcidx = (y * width + ex) * comps;
             uint dstidx = ((y-1) * width + ex) * comps;
             for (uint c = 0; c < comps; c++) {
@@ -212,8 +212,8 @@ void ImageData::extrude(int x, int y, int w, int h) {
     }
     
     // right border
-    if (rx >= 0 && (uint)rx < width-1) {
-        for (uint ey = max(y, 0); (int)ey < y + h; ey++) {
+    if (rx >= 0 && static_cast<uint>(rx) < width-1) {
+        for (uint ey = max(y, 0); static_cast<int>(ey) < y + h; ey++) {
             uint srcidx = (ey * width + rx) * comps;
             uint dstidx = (ey * width + rx + 1) * comps;
             for (uint c = 0; c < comps; c++) {
@@ -223,8 +223,8 @@ void ImageData::extrude(int x, int y, int w, int h) {
     }
 
     // bottom border
-    if (ry >= 0 && (uint)ry < height-1) {
-        for (uint ex = max(x, 0); (int)ex < x + w; ex++) {
+    if (ry >= 0 && static_cast<uint>(ry) < height-1) {
+        for (uint ex = max(x, 0); static_cast<int>(ex) < x + w; ex++) {
             uint srcidx = (ry * width + ex) * comps;
             uint dstidx = ((ry+1) * width + ex) * comps;
             for (uint c = 0; c < comps; c++) {
@@ -235,7 +235,7 @@ void ImageData::extrude(int x, int y, int w, int h) {
 }
 
 void ImageData::fixAlphaColor() {
-    ubyte* pixels = static_cast<ubyte*>(data); 
+    auto pixels = static_cast<ubyte*>(data);
 
     // Fixing black transparent pixels for Mip-Mapping
     for (uint ly = 0; ly < height-1; ly++) {
@@ -263,8 +263,8 @@ ImageData* add_atlas_margins(ImageData* image, int grid_size) {
     int dstwidth = srcwidth + grid_size * 2;
     int dstheight = srcheight + grid_size * 2;
 
-    const ubyte* srcdata = (const ubyte*)image->getData(); 
-    ubyte* dstdata = new ubyte[dstwidth*dstheight * 4];
+    const auto* srcdata = static_cast<const ubyte *>(image->getData());
+    auto dstdata = new ubyte[dstwidth*dstheight * 4];
 
     int imgres = image->getWidth() / grid_size; 
     for (int row = 0; row < grid_size; row++) {

--- a/src/graphics/core/ImageData.hpp
+++ b/src/graphics/core/ImageData.hpp
@@ -27,19 +27,19 @@ public:
     void extrude(int x, int y, int w, int h);
     void fixAlphaColor();
 
-    void* getData() const {
+    [[nodiscard]] void* getData() const {
         return data;
     }
 
-    ImageFormat getFormat() const {
+    [[nodiscard]] ImageFormat getFormat() const {
         return format;
     }
 
-    uint getWidth() const {
+    [[nodiscard]] uint getWidth() const {
         return width;
     }
 
-    uint getHeight() const {
+    [[nodiscard]] uint getHeight() const {
         return height;
     }
 };

--- a/src/graphics/core/LineBatch.cpp
+++ b/src/graphics/core/LineBatch.cpp
@@ -6,7 +6,7 @@
 inline constexpr uint LB_VERTEX_SIZE = (3+4);
 
 LineBatch::LineBatch(size_t capacity) : capacity(capacity) {
-    const vattr attrs[] = { {3},{4}, {0} };
+    constexpr vattr attrs[] = { {3},{4}, {0} };
     buffer = new float[capacity * LB_VERTEX_SIZE * 2];
     mesh = std::make_unique<Mesh>(buffer, 0, attrs);
     index = 0;

--- a/src/graphics/core/Mesh.cpp
+++ b/src/graphics/core/Mesh.cpp
@@ -23,7 +23,7 @@ Mesh::Mesh(const float* vertexBuffer, size_t vertices, const int* indexBuffer, s
     int offset = 0;
     for (int i = 0; attrs[i].size; i++) {
         int size = attrs[i].size;
-        glVertexAttribPointer(i, size, GL_FLOAT, GL_FALSE, vertexSize * sizeof(float), (GLvoid*)(offset * sizeof(float)));
+        glVertexAttribPointer(i, size, GL_FLOAT, GL_FALSE, vertexSize * sizeof(float), reinterpret_cast<GLvoid *>(offset * sizeof(float)));
         glEnableVertexAttribArray(i);
         offset += size;
     }
@@ -62,7 +62,7 @@ void Mesh::reload(const float* vertexBuffer, size_t vertices, const int* indexBu
 void Mesh::draw(unsigned int primitive){
     glBindVertexArray(vao);
     if (ibo != 0) {
-        glDrawElements(primitive, indices, GL_UNSIGNED_INT, 0);
+        glDrawElements(primitive, indices, GL_UNSIGNED_INT, nullptr);
     }
     else {
         glDrawArrays(primitive, 0, vertices);

--- a/src/graphics/core/PostProcessing.cpp
+++ b/src/graphics/core/PostProcessing.cpp
@@ -18,8 +18,7 @@ PostProcessing::PostProcessing() {
     quadMesh = std::make_unique<Mesh>(vertices, 6, attrs);
 }
 
-PostProcessing::~PostProcessing() {
-}
+PostProcessing::~PostProcessing() = default;
 
 void PostProcessing::use(DrawContext& context) {
     const auto& vp = context.getViewport();

--- a/src/graphics/core/PostProcessing.hpp
+++ b/src/graphics/core/PostProcessing.hpp
@@ -35,7 +35,7 @@ public:
     /// @brief Make an image from the last rendered frame
     std::unique_ptr<ImageData> toImage();
 
-    Framebuffer* getFramebuffer() const;
+    [[nodiscard]] Framebuffer* getFramebuffer() const;
 };
 
 #endif // GRAPHICS_CORE_POST_PROCESSING_HPP_

--- a/src/graphics/core/Texture.hpp
+++ b/src/graphics/core/Texture.hpp
@@ -26,10 +26,10 @@ public:
 
     virtual std::unique_ptr<ImageData> readData();
 
-    virtual uint getWidth() const;
-    virtual uint getHeight() const;
+    [[nodiscard]] virtual uint getWidth() const;
+    [[nodiscard]] virtual uint getHeight() const;
 
-    virtual uint getId() const;
+    [[nodiscard]] virtual uint getId() const;
 
     static std::unique_ptr<Texture> from(const ImageData* image);
 };

--- a/src/graphics/core/TextureAnimation.hpp
+++ b/src/graphics/core/TextureAnimation.hpp
@@ -22,7 +22,7 @@ struct Frame {
 class TextureAnimation {
 public:
     TextureAnimation(Texture* srcTex, Texture* dstTex) : srcTexture(srcTex), dstTexture(dstTex) {};
-    ~TextureAnimation() {};
+    ~TextureAnimation() = default;
 
     void addFrame(const Frame& frame) { frames.emplace_back(frame); };
 

--- a/src/graphics/core/Viewport.hpp
+++ b/src/graphics/core/Viewport.hpp
@@ -11,11 +11,11 @@ class Viewport {
 public:
     Viewport(uint width, uint height);
 
-    virtual uint getWidth() const;
-    virtual uint getHeight() const;
+    [[nodiscard]] virtual uint getWidth() const;
+    [[nodiscard]] virtual uint getHeight() const;
 
-    glm::ivec2 size() const {
-        return glm::ivec2(width, height);
+    [[nodiscard]] glm::ivec2 size() const {
+        return {width, height};
     }
 };
 

--- a/src/graphics/render/BlocksPreview.cpp
+++ b/src/graphics/render/BlocksPreview.cpp
@@ -103,7 +103,7 @@ std::unique_ptr<ImageData> BlocksPreview::draw(
         case BlockModel::xsprite: {
             glm::vec3 right = glm::normalize(glm::vec3(1.f, 0.f, -1.f));
             batch->sprite(
-                right*float(size)*0.43f+glm::vec3(0, size*0.4f, 0), 
+                right*static_cast<float>(size)*0.43f+glm::vec3(0, size*0.4f, 0),
                 glm::vec3(0.f, 1.f, 0.f), 
                 right, 
                 size*0.5f, size*0.6f, 
@@ -141,7 +141,7 @@ std::unique_ptr<Atlas> BlocksPreview::build(
 
     shader->use();
     shader->uniformMatrix("u_projview",
-        glm::ortho(0.0f, float(iconSize), 0.0f, float(iconSize), 
+        glm::ortho(0.0f, static_cast<float>(iconSize), 0.0f, static_cast<float>(iconSize),
                     -100.0f, 100.0f) * 
         glm::lookAt(glm::vec3(0.57735f), 
                     glm::vec3(0.0f), 

--- a/src/graphics/render/BlocksRenderer.cpp
+++ b/src/graphics/render/BlocksRenderer.cpp
@@ -60,10 +60,10 @@ void BlocksRenderer::vertex(const vec3& coord, float u, float v, const vec4& lig
         uint32_t integer;
     } compressed;
 
-    compressed.integer = (uint32_t(light.r * 255) & 0xff) << 24;
-    compressed.integer |= (uint32_t(light.g * 255) & 0xff) << 16;
-    compressed.integer |= (uint32_t(light.b * 255) & 0xff) << 8;
-    compressed.integer |= (uint32_t(light.a * 255) & 0xff);
+    compressed.integer = (static_cast<uint32_t>(light.r * 255) & 0xff) << 24;
+    compressed.integer |= (static_cast<uint32_t>(light.g * 255) & 0xff) << 16;
+    compressed.integer |= (static_cast<uint32_t>(light.b * 255) & 0xff) << 8;
+    compressed.integer |= (static_cast<uint32_t>(light.a * 255) & 0xff);
 
     vertexBuffer[vertexOffset++] = compressed.floating;
 }
@@ -377,10 +377,10 @@ vec4 BlocksRenderer::pickLight(int x, int y, int z) const {
         light_t light = voxelsBuffer->pickLight(chunk->x * CHUNK_W + x, 
                                                 y, 
                                                 chunk->z * CHUNK_D + z);
-        return vec4(Lightmap::extract(light, 0) / 15.0f,
+        return {Lightmap::extract(light, 0) / 15.0f,
             Lightmap::extract(light, 1) / 15.0f,
             Lightmap::extract(light, 2) / 15.0f,
-            Lightmap::extract(light, 3) / 15.0f);
+            Lightmap::extract(light, 3) / 15.0f};
     }
     else {
         return vec4(0.0f);

--- a/src/graphics/render/BlocksRenderer.hpp
+++ b/src/graphics/render/BlocksRenderer.hpp
@@ -98,13 +98,13 @@ class BlocksRenderer {
         bool lights
     );
 
-    bool isOpenForLight(int x, int y, int z) const;
-    bool isOpen(int x, int y, int z, ubyte group) const;
+    [[nodiscard]] bool isOpenForLight(int x, int y, int z) const;
+    [[nodiscard]] bool isOpen(int x, int y, int z, ubyte group) const;
 
-    glm::vec4 pickLight(int x, int y, int z) const;
-    glm::vec4 pickLight(const glm::ivec3& coord) const;
-    glm::vec4 pickSoftLight(const glm::ivec3& coord, const glm::ivec3& right, const glm::ivec3& up) const;
-    glm::vec4 pickSoftLight(float x, float y, float z, const glm::ivec3& right, const glm::ivec3& up) const;
+    [[nodiscard]] glm::vec4 pickLight(int x, int y, int z) const;
+    [[nodiscard]] glm::vec4 pickLight(const glm::ivec3& coord) const;
+    [[nodiscard]] glm::vec4 pickSoftLight(const glm::ivec3& coord, const glm::ivec3& right, const glm::ivec3& up) const;
+    [[nodiscard]] glm::vec4 pickSoftLight(float x, float y, float z, const glm::ivec3& right, const glm::ivec3& up) const;
     void render(const voxel* voxels);
 public:
     BlocksRenderer(size_t capacity, const Content* content, const ContentGfxCache* cache, const EngineSettings* settings);
@@ -113,7 +113,7 @@ public:
     void build(const Chunk* chunk, const ChunksStorage* chunks);
     std::shared_ptr<Mesh> render(const Chunk* chunk, const ChunksStorage* chunks);
     std::shared_ptr<Mesh> createMesh();
-    VoxelsVolume* getVoxelsBuffer() const;
+    [[nodiscard]] VoxelsVolume* getVoxelsBuffer() const;
 };
 
 #endif // GRAPHICS_RENDER_BLOCKS_RENDERER_HPP_

--- a/src/graphics/render/ChunksRenderer.cpp
+++ b/src/graphics/render/ChunksRenderer.cpp
@@ -52,8 +52,7 @@ ChunksRenderer::ChunksRenderer(
     );
 }
 
-ChunksRenderer::~ChunksRenderer() {
-}
+ChunksRenderer::~ChunksRenderer() = default;
 
 std::shared_ptr<Mesh> ChunksRenderer::render(std::shared_ptr<Chunk> chunk, bool important) {
     chunk->flags.modified = false;

--- a/src/graphics/render/Skybox.cpp
+++ b/src/graphics/render/Skybox.cpp
@@ -54,8 +54,7 @@ Skybox::Skybox(uint size, Shader* shader)
     });
 }
 
-Skybox::~Skybox() {
-}
+Skybox::~Skybox() = default;
 
 void Skybox::drawBackground(Camera* camera, Assets* assets, int width, int height) {
     Shader* backShader = assets->getShader("background");

--- a/src/graphics/render/Skybox.hpp
+++ b/src/graphics/render/Skybox.hpp
@@ -50,7 +50,7 @@ public:
     void refresh(const DrawContext& pctx, float t, float mie, uint quality);
     void bind() const;
     void unbind() const;
-    bool isReady() const {
+    [[nodiscard]] bool isReady() const {
         return ready;
     }
 };

--- a/src/graphics/render/WorldRenderer.cpp
+++ b/src/graphics/render/WorldRenderer.cpp
@@ -69,8 +69,7 @@ WorldRenderer::WorldRenderer(Engine* engine, LevelFrontend* frontend, Player* pl
     );
 }
 
-WorldRenderer::~WorldRenderer() {
-}
+WorldRenderer::~WorldRenderer() = default;
 
 bool WorldRenderer::drawChunk(
     size_t index,
@@ -125,8 +124,8 @@ void WorldRenderer::drawChunks(Chunks* chunks, Camera* camera, Shader* shader) {
             continue;
         indices.emplace_back(i);
     }
-    float px = camera->position.x / (float)CHUNK_W - 0.5f;
-    float pz = camera->position.z / (float)CHUNK_D - 0.5f;
+    float px = camera->position.x / static_cast<float>(CHUNK_W) - 0.5f;
+    float pz = camera->position.z / static_cast<float>(CHUNK_D) - 0.5f;
     std::sort(indices.begin(), indices.end(), [chunks, px, pz](auto i, auto j) {
         const auto a = chunks->chunks[i].get();
         const auto b = chunks->chunks[j].get();
@@ -141,8 +140,8 @@ void WorldRenderer::drawChunks(Chunks* chunks, Camera* camera, Shader* shader) {
         frustumCulling->update(camera->getProjView());
     }
     chunks->visible = 0;
-    for (size_t i = 0; i < indices.size(); i++){
-        chunks->visible += drawChunk(indices[i], camera, shader, culling);
+    for (unsigned long long indice : indices){
+        chunks->visible += drawChunk(indice, camera, shader, culling);
     }
 }
 

--- a/src/graphics/ui/elements/Button.cpp
+++ b/src/graphics/ui/elements/Button.cpp
@@ -9,13 +9,13 @@ using namespace gui;
 Button::Button(std::shared_ptr<UINode> content, glm::vec4 padding)
     : Panel(glm::vec2(), padding, 0) {
     glm::vec4 margin = getMargin();
-    setSize(content->getSize()+
-            glm::vec2(padding[0]+padding[2]+margin[0]+margin[2],
-                      padding[1]+padding[3]+margin[1]+margin[3]));
-    add(content);
-    setScrollable(false);
-    setHoverColor(glm::vec4(0.05f, 0.1f, 0.15f, 0.75f));
-    setPressedColor(glm::vec4(0.0f, 0.0f, 0.0f, 0.95f));
+    Container::setSize(content->getSize()+
+                       glm::vec2(padding[0]+padding[2]+margin[0]+margin[2],
+                                 padding[1]+padding[3]+margin[1]+margin[3]));
+    Panel::add(content);
+    Container::setScrollable(false);
+    UINode::setHoverColor(glm::vec4(0.05f, 0.1f, 0.15f, 0.75f));
+    UINode::setPressedColor(glm::vec4(0.0f, 0.0f, 0.0f, 0.95f));
     content->setInteractive(false);
 }
 
@@ -32,20 +32,20 @@ Button::Button(
             glm::max(padding.y + padding.w + 16, size.y)
         );
     }
-    setSize(size);
+    Container::setSize(size);
 
     if (action) {
-        listenAction(action);
+        UINode::listenAction(action);
     }
-    setScrollable(false);
+    Container::setScrollable(false);
 
     label = std::make_shared<Label>(text);
     label->setAlign(Align::center);
     label->setSize(size-glm::vec2(padding.z+padding.x, padding.w+padding.y));
     label->setInteractive(false);
-    add(label);
-    setHoverColor(glm::vec4(0.05f, 0.1f, 0.15f, 0.75f));
-    setPressedColor(glm::vec4(0.0f, 0.0f, 0.0f, 0.95f));
+    Panel::add(label);
+    UINode::setHoverColor(glm::vec4(0.05f, 0.1f, 0.15f, 0.75f));
+    UINode::setPressedColor(glm::vec4(0.0f, 0.0f, 0.0f, 0.95f));
 }
 
 void Button::setText(std::wstring text) {

--- a/src/graphics/ui/elements/CheckBox.cpp
+++ b/src/graphics/ui/elements/CheckBox.cpp
@@ -7,8 +7,8 @@
 using namespace gui;
 
 CheckBox::CheckBox(bool checked) : UINode(glm::vec2(32.0f)), checked(checked) {
-    setColor({0.0f, 0.0f, 0.0f, 0.5f});
-    setHoverColor({0.05f, 0.1f, 0.2f, 0.75f});
+    UINode::setColor({0.0f, 0.0f, 0.0f, 0.5f});
+    UINode::setHoverColor({0.05f, 0.1f, 0.2f, 0.75f});
 }
 
 void CheckBox::draw(const DrawContext* pctx, Assets*) {
@@ -45,12 +45,12 @@ CheckBox* CheckBox::setChecked(bool flag) {
 FullCheckBox::FullCheckBox(std::wstring text, glm::vec2 size, bool checked)
     : Panel(size), 
       checkbox(std::make_shared<CheckBox>(checked)){
-    setColor(glm::vec4(0.0f));
-    setOrientation(Orientation::horizontal);
+    UINode::setColor(glm::vec4(0.0f));
+    Panel::setOrientation(Orientation::horizontal);
 
-    add(checkbox);
+    Panel::add(checkbox);
 
     auto label = std::make_shared<Label>(text); 
     label->setMargin(glm::vec4(5.f, 5.f, 0.f, 0.f));
-    add(label);
+    Panel::add(label);
 }

--- a/src/graphics/ui/elements/Container.cpp
+++ b/src/graphics/ui/elements/Container.cpp
@@ -9,7 +9,7 @@ using namespace gui;
 
 Container::Container(glm::vec2 size) : UINode(size) {
     actualLength = size.y;
-    setColor(glm::vec4());
+    UINode::setColor(glm::vec4());
 }
 
 std::shared_ptr<UINode> Container::getAt(glm::vec2 pos, std::shared_ptr<UINode> self) {

--- a/src/graphics/ui/elements/Image.cpp
+++ b/src/graphics/ui/elements/Image.cpp
@@ -9,7 +9,7 @@
 using namespace gui;
 
 Image::Image(std::string texture, glm::vec2 size) : UINode(size), texture(texture) {
-    setInteractive(false);
+    UINode::setInteractive(false);
 }
 
 void Image::draw(const DrawContext* pctx, Assets* assets) {

--- a/src/graphics/ui/elements/InputBindBox.cpp
+++ b/src/graphics/ui/elements/InputBindBox.cpp
@@ -11,8 +11,8 @@ InputBindBox::InputBindBox(Binding& binding, glm::vec4 padding)
     : Panel(glm::vec2(100,32), padding, 0),
       binding(binding) {
     label = std::make_shared<Label>(L"");
-    add(label);
-    setScrollable(false);
+    Panel::add(label);
+    Container::setScrollable(false);
 }
 
 void InputBindBox::drawBackground(const DrawContext* pctx, Assets*) {

--- a/src/graphics/ui/elements/InventoryView.cpp
+++ b/src/graphics/ui/elements/InventoryView.cpp
@@ -108,8 +108,8 @@ SlotView::SlotView(
 ) : UINode(glm::vec2(InventoryView::SLOT_SIZE)),
     layout(layout)
 {
-    setColor(glm::vec4(0, 0, 0, 0.2f));
-    setTooltipDelay(0.05f);
+    UINode::setColor(glm::vec4(0, 0, 0, 0.2f));
+    UINode::setTooltipDelay(0.05f);
 }
 
 void SlotView::draw(const DrawContext* pctx, Assets* assets) {
@@ -303,7 +303,7 @@ ItemStack& SlotView::getStack() {
 }
 
 InventoryView::InventoryView() : Container(glm::vec2()) {
-    setColor(glm::vec4(0, 0, 0, 0.0f));
+    UINode::setColor(glm::vec4(0, 0, 0, 0.0f));
 }
 
 InventoryView::~InventoryView() {}

--- a/src/graphics/ui/elements/Label.cpp
+++ b/src/graphics/ui/elements/Label.cpp
@@ -50,7 +50,7 @@ Label::Label(std::string text, std::string fontName)
     text(util::str2wstr_utf8(text)), 
     fontName(fontName) 
 {
-    setInteractive(false);
+    UINode::setInteractive(false);
     cache.update(this->text, multiline, textWrap);
 }
 
@@ -60,7 +60,7 @@ Label::Label(std::wstring text, std::string fontName)
     text(text), 
     fontName(fontName) 
 {
-    setInteractive(false);
+    UINode::setInteractive(false);
     cache.update(this->text, multiline, textWrap);
 }
 

--- a/src/graphics/ui/elements/Panel.cpp
+++ b/src/graphics/ui/elements/Panel.cpp
@@ -9,7 +9,7 @@ Panel::Panel(glm::vec2 size, glm::vec4 padding, float interval)
     padding(padding), 
     interval(interval) 
 {
-    setColor(glm::vec4(0.0f, 0.0f, 0.0f, 0.75f));
+    UINode::setColor(glm::vec4(0.0f, 0.0f, 0.0f, 0.75f));
 }
 
 Panel::~Panel() {

--- a/src/graphics/ui/elements/TextBox.cpp
+++ b/src/graphics/ui/elements/TextBox.cpp
@@ -16,12 +16,12 @@ TextBox::TextBox(std::wstring placeholder, glm::vec4 padding)
     input(L""),
     placeholder(placeholder)
 {
-    setOnUpPressed(nullptr);
-    setOnDownPressed(nullptr);
+    TextBox::setOnUpPressed(nullptr);
+    TextBox::setOnDownPressed(nullptr);
     label = std::make_shared<Label>(L"");
     label->setSize(size-glm::vec2(padding.z+padding.x, padding.w+padding.y));
-    add(label);
-    setHoverColor(glm::vec4(0.05f, 0.1f, 0.2f, 0.75f));
+    Panel::add(label);
+    UINode::setHoverColor(glm::vec4(0.05f, 0.1f, 0.2f, 0.75f));
 
     textInitX = label->getPos().x;
     scrollable = true;

--- a/src/graphics/ui/elements/TrackBar.cpp
+++ b/src/graphics/ui/elements/TrackBar.cpp
@@ -19,8 +19,8 @@ TrackBar::TrackBar(
     step(step), 
     trackWidth(trackWidth) 
 {
-    setColor(glm::vec4(0.f, 0.f, 0.f, 0.4f));
-    setHoverColor(glm::vec4(0.01f, 0.02f, 0.03f, 0.5f));
+    UINode::setColor(glm::vec4(0.f, 0.f, 0.f, 0.4f));
+    UINode::setHoverColor(glm::vec4(0.01f, 0.02f, 0.03f, 0.5f));
 }
 
 void TrackBar::draw(const DrawContext* pctx, Assets*) {

--- a/src/interfaces/Object.hpp
+++ b/src/interfaces/Object.hpp
@@ -15,7 +15,7 @@ public:
     bool shouldUpdate = true;
 
 public:
-    ~Object() { destroyed(); }
+    ~Object() { Object::destroyed(); }
 
 public:
     virtual void spawned() {  }

--- a/src/util/ThreadPool.hpp
+++ b/src/util/ThreadPool.hpp
@@ -114,7 +114,7 @@ public:
         }
     }
     ~ThreadPool(){
-        terminate();
+        ThreadPool<T, R>::terminate();
     }
 
     bool isActive() const override {


### PR DESCRIPTION
- Resolved various clang-tidy modernize warnings in the graphics module.
- Clarified the behavior of virtual function calls inside destructors and constructors, emphasizing the static binding at compile time.
- Improved code readability and maintainability by addressing potential issues highlighted by clang-tidy.