### PR TITLE
Optimize parameter passing to avoid unnecessary copying

### DIFF
--- a/src/assets/Assets.cpp
+++ b/src/assets/Assets.cpp
@@ -11,59 +11,59 @@
 Assets::~Assets() {
 }
 
-Texture* Assets::getTexture(std::string name) const {
+Texture* Assets::getTexture(const std::string& name) const {
     auto found = textures.find(name);
     if (found == textures.end())
         return nullptr;
     return found->second.get();
 }
 
-void Assets::store(std::unique_ptr<Texture> texture, std::string name){
+void Assets::store(std::unique_ptr<Texture> texture, const std::string& name){
     textures.emplace(name, std::move(texture));
 }
 
 
-Shader* Assets::getShader(std::string name) const{
+Shader* Assets::getShader(const std::string& name) const{
     auto found = shaders.find(name);
     if (found == shaders.end())
         return nullptr;
     return found->second.get();
 }
 
-void Assets::store(std::unique_ptr<Shader> shader, std::string name){
+void Assets::store(std::unique_ptr<Shader> shader, const std::string& name){
     shaders.emplace(name, std::move(shader));
 }
 
-Font* Assets::getFont(std::string name) const {
+Font* Assets::getFont(const std::string& name) const {
     auto found = fonts.find(name);
     if (found == fonts.end())
         return nullptr;
     return found->second.get();
 }
 
-void Assets::store(std::unique_ptr<Font> font, std::string name){
+void Assets::store(std::unique_ptr<Font> font, const std::string& name){
     fonts.emplace(name, std::move(font));
 }
 
-Atlas* Assets::getAtlas(std::string name) const {
+Atlas* Assets::getAtlas(const std::string& name) const {
     auto found = atlases.find(name);
     if (found == atlases.end())
         return nullptr;
     return found->second.get();
 }
 
-void Assets::store(std::unique_ptr<Atlas> atlas, std::string name){
+void Assets::store(std::unique_ptr<Atlas> atlas, const std::string& name){
     atlases.emplace(name, std::move(atlas));
 }
 
-audio::Sound* Assets::getSound(std::string name) const {
+audio::Sound* Assets::getSound(const std::string& name) const {
     auto found = sounds.find(name);
     if (found == sounds.end())
         return nullptr;
     return found->second.get();
 }
 
-void Assets::store(std::unique_ptr<audio::Sound> sound, std::string name) {
+void Assets::store(std::unique_ptr<audio::Sound> sound, const std::string& name) {
     sounds.emplace(name, std::move(sound));
 }
 
@@ -75,13 +75,13 @@ void Assets::store(const TextureAnimation& animation) {
     animations.emplace_back(animation);
 }
 
-UiDocument* Assets::getLayout(std::string name) const {
+UiDocument* Assets::getLayout(const std::string& name) const {
     auto found = layouts.find(name);
     if (found == layouts.end())
         return nullptr;
     return found->second.get();
 }
 
-void Assets::store(std::unique_ptr<UiDocument> layout, std::string name) {
+void Assets::store(std::unique_ptr<UiDocument> layout, const std::string& name) {
     layouts[name] = std::shared_ptr<UiDocument>(std::move(layout));
 }

--- a/src/assets/Assets.hpp
+++ b/src/assets/Assets.hpp
@@ -38,26 +38,26 @@ public:
     Assets(const Assets&) = delete;
     ~Assets();
     
-    Texture* getTexture(std::string name) const;
-    void store(std::unique_ptr<Texture> texture, std::string name);
+    Texture* getTexture(const std::string& name) const;
+    void store(std::unique_ptr<Texture> texture, const std::string& name);
 
-    Shader* getShader(std::string name) const;
-    void store(std::unique_ptr<Shader> shader, std::string name);
+    Shader* getShader(const std::string& name) const;
+    void store(std::unique_ptr<Shader> shader, const std::string& name);
 
-    Font* getFont(std::string name) const;
-    void store(std::unique_ptr<Font> font, std::string name);
+    Font* getFont(const std::string& name) const;
+    void store(std::unique_ptr<Font> font, const std::string& name);
 
-    Atlas* getAtlas(std::string name) const;
-    void store(std::unique_ptr<Atlas> atlas, std::string name);
+    Atlas* getAtlas(const std::string& name) const;
+    void store(std::unique_ptr<Atlas> atlas, const std::string& name);
 
-    audio::Sound* getSound(std::string name) const;
-    void store(std::unique_ptr<audio::Sound> sound, std::string name);
+    audio::Sound* getSound(const std::string& name) const;
+    void store(std::unique_ptr<audio::Sound> sound, const std::string& name);
 
     const std::vector<TextureAnimation>& getAnimations();
     void store(const TextureAnimation& animation);
 
-    UiDocument* getLayout(std::string name) const;
-    void store(std::unique_ptr<UiDocument> layout, std::string name);
+    UiDocument* getLayout(const std::string& name) const;
+    void store(std::unique_ptr<UiDocument> layout, const std::string& name);
 };
 
 #endif // ASSETS_ASSETS_HPP_

--- a/src/assets/AssetsLoader.hpp
+++ b/src/assets/AssetsLoader.hpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <map>
 #include <queue>
+#include <utility>
 
 namespace dynamic {
     class Map;
@@ -38,7 +39,7 @@ struct AssetCfg {
 struct LayoutCfg : AssetCfg {
     scriptenv env;
 
-    LayoutCfg(scriptenv env) : env(env) {}
+    LayoutCfg(scriptenv env) : env(std::move(env)) {}
 };
 
 struct SoundCfg : AssetCfg {
@@ -68,11 +69,11 @@ class AssetsLoader {
     std::queue<aloader_entry> entries;
     const ResPaths* paths;
 
-    void tryAddSound(std::string name);
+    void tryAddSound(const std::string& name);
 
     void processPreload(AssetType tag, const std::string& name, dynamic::Map* map);
     void processPreloadList(AssetType tag, dynamic::List* list);
-    void processPreloadConfig(std::filesystem::path file);
+    void processPreloadConfig(const std::filesystem::path& file);
     void processPreloadConfigs(const Content* content);
 public:
     AssetsLoader(Assets* assets, const ResPaths* paths);
@@ -85,8 +86,8 @@ public:
     /// @param settings asset loading settings (based on asset type)
     void add(
         AssetType tag, 
-        const std::string filename, 
-        const std::string alias, 
+        const std::string& filename,
+        const std::string& alias,
         std::shared_ptr<AssetCfg> settings=nullptr
     );
     
@@ -106,7 +107,7 @@ public:
     static bool loadExternalTexture(
         Assets* assets,
         const std::string& name,
-        std::vector<std::filesystem::path> alternatives
+        const std::vector<std::filesystem::path>& alternatives
     );
 };
 

--- a/src/assets/assetload_funcs.cpp
+++ b/src/assets/assetload_funcs.cpp
@@ -36,9 +36,9 @@ static bool animation(
 assetload::postfunc assetload::texture(
     AssetsLoader*,
     const ResPaths* paths,
-    const std::string filename,
-    const std::string name,
-    std::shared_ptr<AssetCfg>
+    const std::string& filename,
+    const std::string& name,
+    const std::shared_ptr<AssetCfg>&
 ) {
     std::shared_ptr<ImageData> image (
         imageio::read(paths->find(filename+".png").u8string()).release()
@@ -51,9 +51,9 @@ assetload::postfunc assetload::texture(
 assetload::postfunc assetload::shader(
     AssetsLoader*,
     const ResPaths* paths,
-    const std::string filename, 
-    const std::string name,
-    std::shared_ptr<AssetCfg>
+    const std::string& filename,
+    const std::string& name,
+    const std::shared_ptr<AssetCfg>&
 ) {
     fs::path vertexFile = paths->find(filename+".glslv");
     fs::path fragmentFile = paths->find(filename+".glslf");
@@ -88,9 +88,9 @@ static bool append_atlas(AtlasBuilder& atlas, const fs::path& file) {
 assetload::postfunc assetload::atlas(
     AssetsLoader*,
     const ResPaths* paths,
-    const std::string directory, 
-    const std::string name,
-    std::shared_ptr<AssetCfg>
+    const std::string& directory,
+    const std::string& name,
+    const std::shared_ptr<AssetCfg>&
 ) {
     AtlasBuilder builder;
     for (const auto& file : paths->listdir(directory)) {
@@ -113,9 +113,9 @@ assetload::postfunc assetload::atlas(
 assetload::postfunc assetload::font(
     AssetsLoader*,
     const ResPaths* paths,
-    const std::string filename, 
-    const std::string name,
-    std::shared_ptr<AssetCfg>
+    const std::string& filename,
+    const std::string& name,
+    const std::shared_ptr<AssetCfg>&
 ) {
     auto pages = std::make_shared<std::vector<std::unique_ptr<ImageData>>>();
     for (size_t i = 0; i <= 4; i++) {
@@ -136,9 +136,9 @@ assetload::postfunc assetload::font(
 assetload::postfunc assetload::layout(
     AssetsLoader*,
     const ResPaths* paths,
-    const std::string file,
-    const std::string name,
-    std::shared_ptr<AssetCfg> config
+    const std::string& file,
+    const std::string& name,
+    const std::shared_ptr<AssetCfg>& config
 ) {
     return [=](auto assets) {
         try {
@@ -154,9 +154,9 @@ assetload::postfunc assetload::layout(
 assetload::postfunc assetload::sound(
     AssetsLoader*,
     const ResPaths* paths,
-    const std::string file,
-    const std::string name,
-    std::shared_ptr<AssetCfg> config
+    const std::string& file,
+    const std::string& name,
+    const std::shared_ptr<AssetCfg>& config
 ) {
     auto cfg = std::dynamic_pointer_cast<SoundCfg>(config);
     bool keepPCM = cfg ? cfg->keepPCM : false;

--- a/src/assets/assetload_funcs.hpp
+++ b/src/assets/assetload_funcs.hpp
@@ -17,45 +17,45 @@ namespace assetload {
     postfunc texture(
         AssetsLoader*,
         const ResPaths* paths,
-        const std::string filename, 
-        const std::string name,
-        std::shared_ptr<AssetCfg> settings
+        const std::string& filename,
+        const std::string &name,
+        const std::shared_ptr<AssetCfg>& settings
     );
     postfunc shader(
         AssetsLoader*,
         const ResPaths* paths,
-        const std::string filename, 
-        const std::string name,
-        std::shared_ptr<AssetCfg> settings
+        const std::string& filename,
+        const std::string &name,
+        const std::shared_ptr<AssetCfg>& settings
     );
     postfunc atlas(
         AssetsLoader*,
         const ResPaths* paths, 
-        const std::string directory, 
-        const std::string name,
-        std::shared_ptr<AssetCfg> settings
+        const std::string &directory,
+        const std::string &name,
+        const std::shared_ptr<AssetCfg>& settings
     );
     postfunc font(
         AssetsLoader*,
         const ResPaths* paths,
-        const std::string filename, 
-        const std::string name,
-        std::shared_ptr<AssetCfg> settings
+        const std::string& filename,
+        const std::string &name,
+        const std::shared_ptr<AssetCfg>& settings
     );
     postfunc layout(
         AssetsLoader*,
         const ResPaths* paths,
-        const std::string file,
-        const std::string name,
-        std::shared_ptr<AssetCfg> settings
+        const std::string& file,
+        const std::string &name,
+        const std::shared_ptr<AssetCfg>& settings
     );
 
     postfunc sound(
         AssetsLoader*,
         const ResPaths* paths,
-        const std::string file,
-        const std::string name,
-        std::shared_ptr<AssetCfg> settings
+        const std::string& file,
+        const std::string &name,
+        const std::shared_ptr<AssetCfg>& settings
     );
 }
 

--- a/src/audio/AL/ALAudio.cpp
+++ b/src/audio/AL/ALAudio.cpp
@@ -4,12 +4,13 @@
 #include "../../debug/Logger.hpp"
 
 #include <string>
+#include <utility>
 
 static debug::Logger logger("al-audio");
 
 using namespace audio;
 
-ALSound::ALSound(ALAudio* al, uint buffer, std::shared_ptr<PCM> pcm, bool keepPCM) 
+ALSound::ALSound(ALAudio* al, uint buffer, const std::shared_ptr<PCM>& pcm, bool keepPCM)
 : al(al), buffer(buffer) 
 {
     duration = pcm->getDuration();
@@ -36,7 +37,7 @@ std::unique_ptr<Speaker> ALSound::newInstance(int priority, int channel) const {
 }
 
 ALStream::ALStream(ALAudio* al, std::shared_ptr<PCMStream> source, bool keepSource)
-: al(al), source(source), keepSource(keepSource) {
+: al(al), source(std::move(source)), keepSource(keepSource) {
 }
 
 ALStream::~ALStream() {

--- a/src/audio/AL/ALAudio.hpp
+++ b/src/audio/AL/ALAudio.hpp
@@ -29,7 +29,7 @@ namespace audio {
         std::shared_ptr<PCM> pcm;
         duration_t duration;
     public:
-        ALSound(ALAudio* al, uint buffer, std::shared_ptr<PCM> pcm, bool keepPCM);
+        ALSound(ALAudio* al, uint buffer, const std::shared_ptr<PCM>& pcm, bool keepPCM);
         ~ALSound();
 
         duration_t getDuration() const override {

--- a/src/audio/NoAudio.cpp
+++ b/src/audio/NoAudio.cpp
@@ -2,7 +2,7 @@
 
 using namespace audio;
 
-NoSound::NoSound(std::shared_ptr<PCM> pcm, bool keepPCM) {
+NoSound::NoSound(const std::shared_ptr<PCM>& pcm, bool keepPCM) {
     duration = pcm->getDuration();
     if (keepPCM) {
         this->pcm = pcm;

--- a/src/audio/NoAudio.hpp
+++ b/src/audio/NoAudio.hpp
@@ -8,7 +8,7 @@ namespace audio {
         std::shared_ptr<PCM> pcm;
         duration_t duration;
     public:
-        NoSound(std::shared_ptr<PCM> pcm, bool keepPCM);
+        NoSound(const std::shared_ptr<PCM>& pcm, bool keepPCM);
         ~NoSound() {}
 
         duration_t getDuration() const override {
@@ -28,7 +28,7 @@ namespace audio {
         std::shared_ptr<PCMStream> source;
         duration_t duration;
     public:
-        NoStream(std::shared_ptr<PCMStream> source, bool keepSource) {
+        NoStream(const std::shared_ptr<PCMStream>& source, bool keepSource) {
             duration = source->getTotalDuration();
             if (keepSource) {
                 this->source = source;

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 
 namespace audio {
     static speakerid_t nextId = 1;
@@ -19,7 +20,7 @@ namespace audio {
 
 using namespace audio;
 
-Channel::Channel(std::string name) : name(name) {
+Channel::Channel(std::string name) : name(std::move(name)) {
 }
 
 float Channel::getVolume() const {
@@ -175,7 +176,7 @@ std::unique_ptr<Sound> audio::load_sound(const fs::path& file, bool keepPCM) {
 }
 
 std::unique_ptr<Sound> audio::create_sound(std::shared_ptr<PCM> pcm, bool keepPCM) {
-    return backend->createSound(pcm, keepPCM);
+    return backend->createSound(std::move(pcm), keepPCM);
 }
 
 std::unique_ptr<PCMStream> audio::open_PCM_stream(const fs::path& file) {
@@ -204,7 +205,7 @@ std::unique_ptr<Stream> audio::open_stream(const fs::path& file, bool keepSource
 }
 
 std::unique_ptr<Stream> audio::open_stream(std::shared_ptr<PCMStream> stream, bool keepSource) {
-    return backend->openStream(stream, keepSource);
+    return backend->openStream(std::move(stream), keepSource);
 }
 
 
@@ -276,7 +277,7 @@ speakerid_t audio::play(
 }
 
 speakerid_t audio::play(
-    std::shared_ptr<Stream> stream,
+    const std::shared_ptr<Stream>& stream,
     glm::vec3 position,
     bool relative,
     float volume,

--- a/src/audio/audio.hpp
+++ b/src/audio/audio.hpp
@@ -437,7 +437,7 @@ namespace audio {
     /// @param channel channel index
     /// @return speaker id or 0
     speakerid_t play(
-        std::shared_ptr<Stream> stream,
+        const std::shared_ptr<Stream>& stream,
         glm::vec3 position,
         bool relative,
         float volume,

--- a/src/coders/GLSLExtension.cpp
+++ b/src/coders/GLSLExtension.cpp
@@ -8,29 +8,30 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 namespace fs = std::filesystem;
 
 void GLSLExtension::setVersion(std::string version) {
-    this->version = version;
+    this->version = std::move(version);
 }
 
 void GLSLExtension::setPaths(const ResPaths* paths) {
     this->paths = paths;
 }
 
-void GLSLExtension::loadHeader(std::string name) {
+void GLSLExtension::loadHeader(const std::string& name) {
     fs::path file = paths->find("shaders/lib/"+name+".glsl");
     std::string source = files::read_string(file);
     addHeader(name, source);
 }
 
-void GLSLExtension::addHeader(std::string name, std::string source) {
-    headers[name] = source;
+void GLSLExtension::addHeader(const std::string& name, std::string source) {
+    headers[name] = std::move(source);
 }
 
-void GLSLExtension::define(std::string name, std::string value) {
-    defines[name] = value;
+void GLSLExtension::define(const std::string& name, std::string value) {
+    defines[name] = std::move(value);
 }
 
 const std::string& GLSLExtension::getHeader(const std::string& name) const {
@@ -57,7 +58,7 @@ bool GLSLExtension::hasHeader(const std::string& name) const {
     return headers.find(name) != headers.end();
 }
 
-void GLSLExtension::undefine(std::string name) {
+void GLSLExtension::undefine(const std::string& name) {
     if (hasDefine(name)) {
         defines.erase(name);
     }
@@ -66,7 +67,7 @@ void GLSLExtension::undefine(std::string name) {
 inline std::runtime_error parsing_error(
         const fs::path& file, 
         uint linenum, 
-        const std::string message) {
+        const std::string& message) {
     return std::runtime_error("file "+file.string()+": "+message+
                           " at line "+std::to_string(linenum));
 }
@@ -74,7 +75,7 @@ inline std::runtime_error parsing_error(
 inline void parsing_warning(
         const fs::path& file, 
         uint linenum, const 
-        std::string message) {
+        std::string& message) {
     std::cerr << "file "+file.string()+": warning: "+message+
             " at line "+std::to_string(linenum) << std::endl;
 }

--- a/src/coders/GLSLExtension.hpp
+++ b/src/coders/GLSLExtension.hpp
@@ -14,14 +14,14 @@ class GLSLExtension {
     std::string version = "330 core";
 
     const ResPaths* paths = nullptr;
-    void loadHeader(std::string name);
+    void loadHeader(const std::string& name);
 public:
     void setPaths(const ResPaths* paths);
     void setVersion(std::string version);
 
-    void define(std::string name, std::string value);
-    void undefine(std::string name);
-    void addHeader(std::string name, std::string source);
+    void define(const std::string& name, std::string value);
+    void undefine(const std::string& name);
+    void addHeader(const std::string& name, std::string source);
 
     const std::string& getHeader(const std::string& name) const;
     const std::string getDefine(const std::string& name) const;

--- a/src/coders/commons.cpp
+++ b/src/coders/commons.cpp
@@ -15,7 +15,7 @@ inline double power(double base, int64_t power) {
 }
 
 parsing_error::parsing_error(
-    std::string message,
+    const std::string& message,
     std::string_view filename,
     std::string_view source,
     uint pos,
@@ -332,6 +332,6 @@ std::string BasicParser::parseString(char quote, bool closeRequired) {
     return ss.str();
 }
 
-parsing_error BasicParser::error(std::string message) {
+parsing_error BasicParser::error(const std::string& message) {
     return parsing_error(message, filename, source, pos, line, linestart);
 }

--- a/src/coders/commons.hpp
+++ b/src/coders/commons.hpp
@@ -60,7 +60,7 @@ public:
     uint linestart;
 
     parsing_error(
-        std::string message, 
+        const std::string& message,
         std::string_view filename, 
         std::string_view source, 
         uint pos, 
@@ -92,7 +92,7 @@ protected:
     dynamic::Value parseNumber(int sign);
     std::string parseString(char chr, bool closeRequired=true);
 
-    parsing_error error(std::string message);
+    parsing_error error(const std::string& message);
 
 public:
     std::string_view readUntil(char c);

--- a/src/coders/ogg.cpp
+++ b/src/coders/ogg.cpp
@@ -80,7 +80,7 @@ class OggStream : public PCMStream {
     size_t totalSamples = 0;
     bool seekable;
 public:
-    OggStream(OggVorbis_File vf) : vf(std::move(vf)) {
+    OggStream(OggVorbis_File vf) : vf(vf) {
         vorbis_info* info = ov_info(&vf, -1);
         channels = info->channels;
         sampleRate = info->rate;
@@ -158,5 +158,5 @@ std::unique_ptr<PCMStream> ogg::create_stream(const fs::path& file) {
     if ((code = ov_fopen(file.u8string().c_str(), &vf))) {
         throw std::runtime_error("vorbis: "+vorbis_error_message(code));
     }
-    return std::make_unique<OggStream>(std::move(vf));
+    return std::make_unique<OggStream>(vf);
 }

--- a/src/coders/xml.cpp
+++ b/src/coders/xml.cpp
@@ -5,12 +5,13 @@
 #include <charconv>
 #include <stdexcept>
 #include <sstream>
+#include <utility>
 
 using namespace xml;
 
 Attribute::Attribute(std::string name, std::string text)
-    : name(name), 
-      text(text) {
+    : name(std::move(name)),
+      text(std::move(text)) {
 }
 
 const std::string& Attribute::getName() const {
@@ -104,14 +105,14 @@ glm::vec4 Attribute::asColor() const {
     }
 }
 
-Node::Node(std::string tag) : tag(tag) {
+Node::Node(std::string tag) : tag(std::move(tag)) {
 }
 
-void Node::add(xmlelement element) {
+void Node::add(const xmlelement& element) {
     elements.push_back(element);
 }
 
-void Node::set(std::string name, std::string text) {
+void Node::set(const std::string& name, const std::string &text) {
     attrs[name] = Attribute(name, text);
 }
 
@@ -157,11 +158,11 @@ const xmlelements_map& Node::getAttributes() const {
 }
 
 Document::Document(std::string version, std::string encoding)
-    : version(version),
-      encoding(encoding) {
+    : version(std::move(version)),
+      encoding(std::move(encoding)) {
 }
 
-void Document::setRoot(xmlelement element) {
+void Document::setRoot(const xmlelement &element) {
     this->root = element;
 }
 
@@ -336,7 +337,7 @@ xmldocument Parser::parse() {
     return document;
 }
 
-xmldocument xml::parse(std::string filename, std::string source) {
+xmldocument xml::parse(const std::string& filename, const std::string& source) {
     Parser parser(filename, source);
     return parser.parse();
 }
@@ -357,7 +358,7 @@ inline void newline(
 
 static void stringifyElement(
     std::stringstream& ss,
-    const xmlelement element,
+    const xmlelement& element,
     bool nice,
     const std::string& indentStr,
     int indent
@@ -414,7 +415,7 @@ static void stringifyElement(
 }
 
 std::string xml::stringify(
-    const xmldocument document,
+    const xmldocument& document,
     bool nice,
     const std::string& indentStr
 ) {

--- a/src/coders/xml.hpp
+++ b/src/coders/xml.hpp
@@ -46,12 +46,12 @@ namespace xml {
         Node(std::string tag);
 
         /// @brief Add sub-element
-        void add(xmlelement element);
+        void add(const xmlelement& element);
 
         /// @brief Set attribute value. Creates attribute if does not exists
         /// @param name attribute name
         /// @param text attribute value
-        void set(std::string name, std::string text);
+        void set(const std::string& name, const std::string &text);
         
         /// @brief Get element tag
         const std::string& getTag() const;
@@ -101,7 +101,7 @@ namespace xml {
     public:
         Document(std::string version, std::string encoding);
 
-        void setRoot(xmlelement element);
+        void setRoot(const xmlelement &element);
         xmlelement getRoot() const;
 
         const std::string& getVersion() const;
@@ -129,7 +129,7 @@ namespace xml {
     /// @param indentStr indentation characters sequence (default - 4 spaces)
     /// @return XML string
     extern std::string stringify(
-        const xmldocument document,
+        const xmldocument& document,
         bool nice=true,
         const std::string& indentStr="    "
     );
@@ -138,7 +138,7 @@ namespace xml {
     /// @param filename file name will be shown in error messages
     /// @param source xml source code string
     /// @return xml document
-    extern xmldocument parse(std::string filename, std::string source);
+    extern xmldocument parse(const std::string& filename, const std::string& source);
 }
 
 #endif // CODERS_XML_HPP_

--- a/src/content/Content.cpp
+++ b/src/content/Content.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <stdexcept>
 #include <glm/glm.hpp>
+#include <utility>
 
 #include "../voxels/Block.hpp"
 #include "../items/ItemDef.hpp"
@@ -13,8 +14,8 @@
 ContentIndices::ContentIndices(
     std::vector<Block*> blockDefs, 
     std::vector<ItemDef*> itemDefs
-) : blockDefs(blockDefs), 
-    itemDefs(itemDefs) 
+) : blockDefs(std::move(blockDefs)),
+    itemDefs(std::move(itemDefs))
 {}
 
 Content::Content(
@@ -35,7 +36,7 @@ Content::Content(
 Content::~Content() {
 }
 
-Block* Content::findBlock(std::string id) const {
+Block* Content::findBlock(const std::string& id) const {
     auto found = blockDefs.find(id);
     if (found == blockDefs.end()) {
         return nullptr;
@@ -43,7 +44,7 @@ Block* Content::findBlock(std::string id) const {
     return found->second.get();
 }
 
-Block& Content::requireBlock(std::string id) const {
+Block& Content::requireBlock(const std::string& id) const {
     auto found = blockDefs.find(id);
     if (found == blockDefs.end()) {
         throw std::runtime_error("missing block "+id);
@@ -51,7 +52,7 @@ Block& Content::requireBlock(std::string id) const {
     return *found->second;
 }
 
-ItemDef* Content::findItem(std::string id) const {
+ItemDef* Content::findItem(const std::string& id) const {
     auto found = itemDefs.find(id);
     if (found == itemDefs.end()) {
         return nullptr;
@@ -59,7 +60,7 @@ ItemDef* Content::findItem(std::string id) const {
     return found->second.get();
 }
 
-ItemDef& Content::requireItem(std::string id) const {
+ItemDef& Content::requireItem(const std::string& id) const {
     auto found = itemDefs.find(id);
     if (found == itemDefs.end()) {
         throw std::runtime_error("missing item "+id);
@@ -67,7 +68,7 @@ ItemDef& Content::requireItem(std::string id) const {
     return *found->second;
 }
 
-const BlockMaterial* Content::findBlockMaterial(std::string id) const {
+const BlockMaterial* Content::findBlockMaterial(const std::string& id) const {
     auto found = blockMaterials.find(id);
     if (found == blockMaterials.end()) {
         return nullptr;
@@ -75,7 +76,7 @@ const BlockMaterial* Content::findBlockMaterial(std::string id) const {
     return found->second.get();
 }
 
-const ContentPackRuntime* Content::getPackRuntime(std::string id) const {
+const ContentPackRuntime* Content::getPackRuntime(const std::string& id) const {
     auto found = packs.find(id);
     if (found == packs.end()) {
         return nullptr;

--- a/src/content/Content.hpp
+++ b/src/content/Content.hpp
@@ -107,15 +107,15 @@ public:
         return indices.get();
     }
     
-    Block* findBlock(std::string id) const;
-    Block& requireBlock(std::string id) const;
+    Block* findBlock(const std::string& id) const;
+    Block& requireBlock(const std::string& id) const;
 
-    ItemDef* findItem(std::string id) const;
-    ItemDef& requireItem(std::string id) const;
+    ItemDef* findItem(const std::string& id) const;
+    ItemDef& requireItem(const std::string& id) const;
 
-    const BlockMaterial* findBlockMaterial(std::string id) const;
+    const BlockMaterial* findBlockMaterial(const std::string& id) const;
 
-    const ContentPackRuntime* getPackRuntime(std::string id) const;
+    const ContentPackRuntime* getPackRuntime(const std::string& id) const;
 
     const std::unordered_map<std::string, std::unique_ptr<BlockMaterial>>& getBlockMaterials() const;
     const std::unordered_map<std::string, std::unique_ptr<ContentPackRuntime>>& getPacks() const;

--- a/src/content/ContentBuilder.cpp
+++ b/src/content/ContentBuilder.cpp
@@ -6,7 +6,7 @@ void ContentBuilder::add(std::unique_ptr<ContentPackRuntime> pack) {
     packs[pack->getId()] = std::move(pack);
 }
 
-Block& ContentBuilder::createBlock(std::string id) {
+Block& ContentBuilder::createBlock(const std::string& id) {
     auto found = blockDefs.find(id);
     if (found != blockDefs.end()) {
         return *found->second;
@@ -17,7 +17,7 @@ Block& ContentBuilder::createBlock(std::string id) {
     return *blockDefs[id];
 }
 
-ItemDef& ContentBuilder::createItem(std::string id) {
+ItemDef& ContentBuilder::createItem(const std::string& id) {
     auto found = itemDefs.find(id);
     if (found != itemDefs.end()) {
         return *found->second;
@@ -28,21 +28,21 @@ ItemDef& ContentBuilder::createItem(std::string id) {
     return *itemDefs[id];
 }
 
-BlockMaterial& ContentBuilder::createBlockMaterial(std::string id) {
+BlockMaterial& ContentBuilder::createBlockMaterial(const std::string& id) {
     blockMaterials[id] = std::make_unique<BlockMaterial>();
     auto& material = *blockMaterials[id];
     material.name = id;
     return material;
 }
 
-void ContentBuilder::checkIdentifier(std::string id) {
+void ContentBuilder::checkIdentifier(const std::string& id) {
     contenttype result;
     if (((result = checkContentType(id)) != contenttype::none)) {
         throw namereuse_error("name "+id+" is already used", result);
     }  
 }
 
-contenttype ContentBuilder::checkContentType(std::string id) {
+contenttype ContentBuilder::checkContentType(const std::string& id) {
     if (blockDefs.find(id) != blockDefs.end()) {
         return contenttype::block;
     }

--- a/src/content/ContentBuilder.hpp
+++ b/src/content/ContentBuilder.hpp
@@ -24,12 +24,12 @@ public:
 
     void add(std::unique_ptr<ContentPackRuntime> pack);
 
-    Block& createBlock(std::string id);
-    ItemDef& createItem(std::string id);
-    BlockMaterial& createBlockMaterial(std::string id);
+    Block& createBlock(const std::string& id);
+    ItemDef& createItem(const std::string& id);
+    BlockMaterial& createBlockMaterial(const std::string& id);
 
-    void checkIdentifier(std::string id);
-    contenttype checkContentType(std::string id);
+    void checkIdentifier(const std::string& id);
+    contenttype checkContentType(const std::string& id);
 
     std::unique_ptr<Content> build();
 };

--- a/src/content/ContentLUT.hpp
+++ b/src/content/ContentLUT.hpp
@@ -7,6 +7,7 @@
 #include "../constants.hpp"
 
 #include <string>
+#include <utility>
 #include <vector>
 #include <filesystem>
 
@@ -44,7 +45,7 @@ public:
 
     inline void setBlock(blockid_t index, std::string name, blockid_t id) {
         blocks[index] = id;
-        blockNames[index] = name;
+        blockNames[index] = std::move(name);
         if (id == BLOCK_VOID) {
             missingContent = true;
         } else if (index != id) {
@@ -62,7 +63,7 @@ public:
 
     inline void setItem(itemid_t index, std::string name, itemid_t id) {
         items[index] = id;
-        itemNames[index] = name;
+        itemNames[index] = std::move(name);
         if (id == ITEM_VOID) {
             missingContent = true;
         } else if (index != id) {

--- a/src/content/ContentLoader.cpp
+++ b/src/content/ContentLoader.cpp
@@ -28,15 +28,15 @@ ContentLoader::ContentLoader(ContentPack* pack) : pack(pack) {
 }
 
 bool ContentLoader::fixPackIndices(
-    fs::path folder, 
+    const fs::path& folder,
     dynamic::Map* indicesRoot,
-    std::string contentSection
+    const std::string& contentSection
 ) {
     std::vector<std::string> detected;
     std::vector<std::string> indexed;
     if (fs::is_directory(folder)) {
-        for (auto entry : fs::directory_iterator(folder)) {
-            fs::path file = entry.path();
+        for (const auto& entry : fs::directory_iterator(folder)) {
+            const fs::path& file = entry.path();
             if (fs::is_regular_file(file) && file.extension() == ".json") {
                 std::string name = file.stem().string();
                 if (name[0] == '_')
@@ -46,8 +46,8 @@ bool ContentLoader::fixPackIndices(
                 std::string space = file.stem().string();
                 if (space[0] == '_')
                     continue;
-                for (auto entry : fs::directory_iterator(file)) {
-                    fs::path file = entry.path();
+                for (const auto& entry : fs::directory_iterator(file)) {
+                    const fs::path& file = entry.path();
                     if (fs::is_regular_file(file) && file.extension() == ".json") {
                         std::string name = file.stem().string();
                         if (name[0] == '_')
@@ -109,7 +109,7 @@ void ContentLoader::fixPackIndices() {
     }
 }
 
-void ContentLoader::loadBlock(Block& def, std::string name, fs::path file) {
+void ContentLoader::loadBlock(Block& def, const std::string& name, const fs::path& file) {
     auto root = files::read_json(file);
 
     root->str("caption", def.caption);
@@ -266,7 +266,7 @@ void ContentLoader::loadCustomBlockModel(Block& def, dynamic::Map* primitives) {
     }
 }
 
-void ContentLoader::loadItem(ItemDef& def, std::string name, fs::path file) {
+void ContentLoader::loadItem(ItemDef& def, const std::string& name, const fs::path& file) {
     auto root = files::read_json(file);
     root->str("caption", def.caption);
 
@@ -295,7 +295,7 @@ void ContentLoader::loadItem(ItemDef& def, std::string name, fs::path file) {
     }
 }
 
-void ContentLoader::loadBlock(Block& def, std::string full, std::string name) {
+void ContentLoader::loadBlock(Block& def, const std::string& full, const std::string& name) {
     auto folder = pack->folder;
 
     fs::path configFile = folder/fs::path("blocks/"+name+".json");
@@ -307,7 +307,7 @@ void ContentLoader::loadBlock(Block& def, std::string full, std::string name) {
     }
 }
 
-void ContentLoader::loadItem(ItemDef& def, std::string full, std::string name) {
+void ContentLoader::loadItem(ItemDef& def, const std::string& full, const std::string& name) {
     auto folder = pack->folder;
 
     fs::path configFile = folder/fs::path("items/"+name+".json");
@@ -319,7 +319,7 @@ void ContentLoader::loadItem(ItemDef& def, std::string full, std::string name) {
     }
 }
 
-void ContentLoader::loadBlockMaterial(BlockMaterial& def, fs::path file) {
+void ContentLoader::loadBlockMaterial(BlockMaterial& def, const fs::path& file) {
     auto root = files::read_json(file);
     root->str("steps-sound", def.stepsSound);
     root->str("place-sound", def.placeSound);
@@ -394,8 +394,8 @@ void ContentLoader::load(ContentBuilder& builder) {
 
     fs::path materialsDir = folder / fs::u8path("block_materials");
     if (fs::is_directory(materialsDir)) {
-        for (auto entry : fs::directory_iterator(materialsDir)) {
-            fs::path file = entry.path();
+        for (const auto& entry : fs::directory_iterator(materialsDir)) {
+            const fs::path& file = entry.path();
             std::string name = pack->id+":"+file.stem().u8string();
             loadBlockMaterial(builder.createBlockMaterial(name), file);
         }

--- a/src/content/ContentLoader.hpp
+++ b/src/content/ContentLoader.hpp
@@ -22,21 +22,21 @@ class ContentLoader {
     const ContentPack* pack;
     scriptenv env;
 
-    void loadBlock(Block& def, std::string full, std::string name);
+    void loadBlock(Block& def, const std::string& full, const std::string& name);
     void loadCustomBlockModel(Block& def, dynamic::Map* primitives);
-    void loadItem(ItemDef& def, std::string full, std::string name);
-    void loadBlockMaterial(BlockMaterial& def, fs::path file);
+    void loadItem(ItemDef& def, const std::string& full, const std::string& name);
+    void loadBlockMaterial(BlockMaterial& def, const fs::path& file);
 public:
     ContentLoader(ContentPack* pack);
 
     bool fixPackIndices(
-        fs::path folder,
+        const fs::path& folder,
         dynamic::Map* indicesRoot,
-        std::string contentSection
+        const std::string& contentSection
     );
     void fixPackIndices();
-    void loadBlock(Block& def, std::string name, fs::path file);
-    void loadItem(ItemDef& def, std::string name, fs::path file);
+    void loadBlock(Block& def, const std::string& name, const fs::path& file);
+    void loadItem(ItemDef& def, const std::string& name, const fs::path& file);
     void load(ContentBuilder& builder);
 };
 

--- a/src/content/ContentPack.hpp
+++ b/src/content/ContentPack.hpp
@@ -16,7 +16,7 @@ class contentpack_error : public std::runtime_error {
     std::string packId;
     fs::path folder;
 public:
-    contentpack_error(std::string packId, fs::path folder, std::string message);
+    contentpack_error(std::string packId, fs::path folder, const std::string& message);
 
     std::string getPackId() const;
     fs::path getFolder() const;
@@ -52,20 +52,20 @@ struct ContentPack {
     static const fs::path ITEMS_FOLDER;
     static const std::vector<std::string> RESERVED_NAMES;
 
-    static bool is_pack(fs::path folder);
-    static ContentPack read(fs::path folder);
+    static bool is_pack(const fs::path& folder);
+    static ContentPack read(const fs::path& folder);
 
     static void scanFolder(
-        fs::path folder,
+        const fs::path& folder,
         std::vector<ContentPack>& packs
     );
     
-    static std::vector<std::string> worldPacksList(fs::path folder);
+    static std::vector<std::string> worldPacksList(const fs::path& folder);
 
     static fs::path findPack(
         const EnginePaths* paths, 
-        fs::path worldDir, 
-        std::string name
+        const fs::path& worldDir,
+        const std::string& name
     );
 };
 

--- a/src/data/dynamic.cpp
+++ b/src/data/dynamic.cpp
@@ -110,7 +110,7 @@ void Map::str(const std::string& key, std::string& dst) const {
     dst = get(key, dst);
 }
 
-std::string Map::get(const std::string& key, const std::string def) const {
+std::string Map::get(const std::string& key, const std::string& def) const {
     auto found = values.find(key);
     if (found == values.end())
         return def;
@@ -213,7 +213,7 @@ void Map::flag(const std::string& key, bool& dst) const {
     dst = get(key, dst);
 }
 
-Map& Map::put(std::string key, const Value& value) {
+Map& Map::put(const std::string& key, const Value& value) {
     values[key] = value;
     return *this;
 }
@@ -222,13 +222,13 @@ void Map::remove(const std::string& key) {
     values.erase(key);
 }
 
-List& Map::putList(std::string key) {
+List& Map::putList(const std::string& key) {
     auto arr = create_list();
     put(key, arr);
     return *arr;
 }
 
-Map& Map::putMap(std::string key) {
+Map& Map::putMap(const std::string& key) {
     auto obj = create_map();
     put(key, obj);
     return *obj;

--- a/src/data/dynamic.hpp
+++ b/src/data/dynamic.hpp
@@ -101,7 +101,7 @@ namespace dynamic {
             return get(key, T());
         }
 
-        std::string get(const std::string& key, const std::string def) const;
+        std::string get(const std::string& key, const std::string& def) const;
         number_t get(const std::string& key, double def) const;
         integer_t get(const std::string& key, integer_t def) const;
         bool get(const std::string& key, bool def) const;
@@ -155,12 +155,12 @@ namespace dynamic {
         Map& put(std::string key, const char* value) {
             return put(key, Value(value));
         }
-        Map& put(std::string key, const Value& value);
+        Map& put(const std::string& key, const Value& value);
 
         void remove(const std::string& key);
 
-        List& putList(std::string key);
-        Map& putMap(std::string key);
+        List& putList(const std::string& key);
+        Map& putMap(const std::string& key);
 
         bool has(const std::string& key) const;
         size_t size() const;

--- a/src/debug/Logger.cpp
+++ b/src/debug/Logger.cpp
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <chrono>
 #include <iostream>
+#include <utility>
 
 using namespace debug;
 
@@ -16,10 +17,10 @@ LogMessage::~LogMessage() {
     logger->log(level, ss.str());
 }
 
-Logger::Logger(std::string name) : name(name) {
+Logger::Logger(std::string name) : name(std::move(name)) {
 }
 
-void Logger::log(LogLevel level, const std::string& name, std::string message) {
+void Logger::log(LogLevel level, const std::string& name, const std::string& message) {
     using namespace std::chrono;
 
     std::stringstream ss;
@@ -72,5 +73,5 @@ void Logger::flush() {
 }
 
 void Logger::log(LogLevel level, std::string message) {
-    log(level, name, message);
+    log(level, name, std::move(message));
 }

--- a/src/debug/Logger.hpp
+++ b/src/debug/Logger.hpp
@@ -35,7 +35,7 @@ namespace debug {
 
         std::string name;
    
-        static void log(LogLevel level, const std::string& name, std::string message);
+        static void log(LogLevel level, const std::string& name, const std::string& message);
     public:
         static void init(const std::string& filename);
         static void flush();

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -42,6 +42,7 @@
 #include <glm/glm.hpp>
 #include <unordered_set>
 #include <functional>
+#include <utility>
 
 static debug::Logger logger("engine");
 
@@ -347,11 +348,11 @@ double Engine::getDelta() const {
 void Engine::setScreen(std::shared_ptr<Screen> screen) {
     audio::reset_channel(audio::get_channel_index("regular"));
     audio::reset_channel(audio::get_channel_index("ambient"));
-    this->screen = screen;
+    this->screen = std::move(screen);
 }
 
 void Engine::setLanguage(std::string locale) {
-    langs::setup(paths->getResources(), locale, contentPacks);
+    langs::setup(paths->getResources(), std::move(locale), contentPacks);
     gui->getMenu()->setPageLoader(menus::create_page_loader(this));
 }
 
@@ -391,7 +392,7 @@ std::shared_ptr<Screen> Engine::getScreen() {
     return screen;
 }
 
-void Engine::postRunnable(runnable callback) {
+void Engine::postRunnable(const runnable& callback) {
     std::lock_guard<std::recursive_mutex> lock(postRunnablesMutex);
     postRunnables.push(callback);
 }

--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -137,7 +137,7 @@ public:
     std::shared_ptr<Screen> getScreen();
 
     /// @brief Enqueue function call to the end of current frame in draw thread
-    void postRunnable(runnable callback);
+    void postRunnable(const runnable& callback);
 
     void saveScreenshot();
 

--- a/src/files/WorldConverter.hpp
+++ b/src/files/WorldConverter.hpp
@@ -32,17 +32,17 @@ class WorldConverter : public Task {
     runnable onComplete;
     uint tasksDone = 0;
 
-    void convertPlayer(fs::path file) const;
-    void convertRegion(fs::path file) const;
+    void convertPlayer(const fs::path& file) const;
+    void convertRegion(const fs::path& file) const;
 public:
     WorldConverter(
-        fs::path folder, 
+        const fs::path& folder,
         const Content* content, 
         std::shared_ptr<ContentLUT> lut
     );
     ~WorldConverter();
 
-    void convert(convert_task task) const;
+    void convert(const convert_task& task) const;
     void convertNext();
     void setOnComplete(runnable callback);
     void write();
@@ -55,10 +55,10 @@ public:
     uint getWorkDone() const override;
 
     static std::shared_ptr<Task> startTask(
-        fs::path folder, 
+        const fs::path& folder,
         const Content* content, 
-        std::shared_ptr<ContentLUT> lut,
-        runnable onDone,
+        const std::shared_ptr<ContentLUT>& lut,
+        const runnable& onDone,
         bool multithreading
     );
 };

--- a/src/files/WorldFiles.cpp
+++ b/src/files/WorldFiles.cpp
@@ -27,14 +27,15 @@
 #include <fstream>
 #include <sstream>
 #include <cstring>
+#include <utility>
 
 #define WORLD_FORMAT_MAGIC ".VOXWLD"
 
-WorldFiles::WorldFiles(fs::path directory) : directory(directory), regions(directory) {
+WorldFiles::WorldFiles(const fs::path& directory) : directory(directory), regions(directory) {
 }
 
-WorldFiles::WorldFiles(fs::path directory, const DebugSettings& settings)
-  : WorldFiles(directory) 
+WorldFiles::WorldFiles(const fs::path& directory, const DebugSettings& settings)
+  : WorldFiles(directory)
 {
     generatorTestMode = settings.generatorTestMode.get();
     doWriteLights = settings.doWriteLights.get();

--- a/src/files/WorldFiles.hpp
+++ b/src/files/WorldFiles.hpp
@@ -41,8 +41,8 @@ class WorldFiles {
     void writeWorldInfo(const World* world);
     void writeIndices(const ContentIndices* indices);
 public:
-    WorldFiles(fs::path directory);
-    WorldFiles(fs::path directory, const DebugSettings& settings);
+    WorldFiles(const fs::path &directory);
+    WorldFiles(const fs::path &directory, const DebugSettings& settings);
     ~WorldFiles();
 
     fs::path getPlayerFile() const;

--- a/src/files/WorldRegions.cpp
+++ b/src/files/WorldRegions.cpp
@@ -8,10 +8,11 @@
 #include "../util/data_io.hpp"
 
 #include <cstring>
+#include <utility>
 
 #define REGION_FORMAT_MAGIC ".VOXREG"
 
-regfile::regfile(fs::path filename) : file(filename) {
+regfile::regfile(fs::path filename) : file(std::move(filename)) {
     if (file.length() < REGION_HEADER_SIZE)
         throw std::runtime_error("incomplete region file header");
     char header[REGION_HEADER_SIZE];
@@ -92,7 +93,7 @@ uint WorldRegion::getChunkDataSize(uint x, uint z) {
     return sizes[z * REGION_SIZE + x];
 }
 
-WorldRegions::WorldRegions(fs::path directory) : directory(directory) {
+WorldRegions::WorldRegions(const fs::path& directory) : directory(directory) {
     for (uint i = 0; i < sizeof(layers)/sizeof(RegionsLayer); i++) {
         layers[i].layer = i;
     }
@@ -427,7 +428,7 @@ chunk_inventories_map WorldRegions::fetchInventories(int x, int z) {
     return inventories;
 }
 
-void WorldRegions::processRegionVoxels(int x, int z, regionproc func) {
+void WorldRegions::processRegionVoxels(int x, int z, const regionproc& func) {
     if (getRegion(x, z, REGION_LAYER_VOXELS)) {
         throw std::runtime_error("not implemented for in-memory regions");
     }

--- a/src/files/WorldRegions.hpp
+++ b/src/files/WorldRegions.hpp
@@ -128,7 +128,7 @@ public:
     bool generatorTestMode = false;
     bool doWriteLights = true;
 
-    WorldRegions(fs::path directory);
+    WorldRegions(const fs::path &directory);
     WorldRegions(const WorldRegions&) = delete;
     ~WorldRegions();
 
@@ -148,7 +148,7 @@ public:
     std::unique_ptr<light_t[]> getLights(int x, int z);
     chunk_inventories_map fetchInventories(int x, int z);
 
-    void processRegionVoxels(int x, int z, regionproc func);
+    void processRegionVoxels(int x, int z, const regionproc& func);
 
     fs::path getRegionsFolder(int layer) const;
 

--- a/src/files/engine_paths.cpp
+++ b/src/files/engine_paths.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <filesystem>
 #include <algorithm>
+#include <utility>
 
 #include "../util/stringutil.hpp"
 #include "../typedefs.hpp"
@@ -21,7 +22,7 @@ fs::path EnginePaths::getResources() const {
     return resources;
 }
 
-fs::path EnginePaths::getScreenshotFile(std::string ext) {
+fs::path EnginePaths::getScreenshotFile(const std::string& ext) {
     fs::path folder = userfiles/fs::path(SCREENSHOTS_FOLDER);
     if (!fs::is_directory(folder)) {
         fs::create_directory(folder);
@@ -75,11 +76,11 @@ std::vector<fs::path> EnginePaths::scanForWorlds() {
     if (!fs::is_directory(folder))
         return folders;
     
-    for (auto entry : fs::directory_iterator(folder)) {
+    for (const auto& entry : fs::directory_iterator(folder)) {
         if (!entry.is_directory()) {
             continue;
         }
-        fs::path worldFolder = entry.path();
+        const fs::path& worldFolder = entry.path();
         fs::path worldFile = worldFolder/fs::u8path(WorldFiles::WORLD_FILE);
         if (!fs::is_regular_file(worldFile)) {
             continue;
@@ -94,20 +95,20 @@ std::vector<fs::path> EnginePaths::scanForWorlds() {
     return folders;
 }
 
-bool EnginePaths::isWorldNameUsed(std::string name) {
+bool EnginePaths::isWorldNameUsed(const std::string& name) {
     return fs::exists(EnginePaths::getWorldsFolder()/fs::u8path(name));
 }
 
 void EnginePaths::setUserfiles(fs::path folder) {
-    this->userfiles = folder;
+    this->userfiles = std::move(folder);
 }
 
 void EnginePaths::setResources(fs::path folder) {
-    this->resources = folder;
+    this->resources = std::move(folder);
 }
 
 void EnginePaths::setWorldFolder(fs::path folder) {
-    this->worldFolder = folder;
+    this->worldFolder = std::move(folder);
 }
 
 void EnginePaths::setContentPacks(std::vector<ContentPack>* contentPacks) {
@@ -139,7 +140,7 @@ static fs::path toCanonic(fs::path path) {
     return path;
 }
 
-fs::path EnginePaths::resolve(std::string path, bool throwErr) {
+fs::path EnginePaths::resolve(const std::string& path, bool throwErr) {
     size_t separator = path.find(':');
     if (separator == std::string::npos) {
         throw files_access_error("no entry point specified");
@@ -172,7 +173,7 @@ fs::path EnginePaths::resolve(std::string path, bool throwErr) {
 }
 
 ResPaths::ResPaths(fs::path mainRoot, std::vector<PathsRoot> roots) 
-    : mainRoot(mainRoot), roots(roots) {
+    : mainRoot(std::move(mainRoot)), roots(std::move(roots)) {
 }
 
 fs::path ResPaths::find(const std::string& filename) const {

--- a/src/files/engine_paths.hpp
+++ b/src/files/engine_paths.hpp
@@ -24,14 +24,14 @@ public:
     fs::path getUserfiles() const;
     fs::path getResources() const;
     
-    fs::path getScreenshotFile(std::string ext);
+    fs::path getScreenshotFile(const std::string& ext);
     fs::path getWorldsFolder();
     fs::path getWorldFolder();
     fs::path getWorldFolder(const std::string& name);
     fs::path getControlsFile();
     fs::path getControlsFileOld(); // TODO: remove in 0.22
     fs::path getSettingsFile();
-    bool isWorldNameUsed(std::string name);
+    bool isWorldNameUsed(const std::string& name);
 
     void setUserfiles(fs::path folder);
     void setResources(fs::path folder);
@@ -40,7 +40,7 @@ public:
 
     std::vector<fs::path> scanForWorlds();
 
-    fs::path resolve(std::string path, bool throwErr=true);
+    fs::path resolve(const std::string& path, bool throwErr=true);
 };
 
 struct PathsRoot {

--- a/src/files/files.cpp
+++ b/src/files/files.cpp
@@ -15,7 +15,7 @@
 
 namespace fs = std::filesystem;
 
-files::rafile::rafile(fs::path filename)
+files::rafile::rafile(const fs::path& filename)
     : file(filename, std::ios::binary | std::ios::ate) {
     if (!file) {
         throw std::runtime_error("could not to open file "+filename.string());
@@ -36,7 +36,7 @@ void files::rafile::read(char* buffer, std::streamsize size) {
     file.read(buffer, size);
 }
 
-bool files::write_bytes(fs::path filename, const ubyte* data, size_t size) {
+bool files::write_bytes(const fs::path& filename, const ubyte* data, size_t size) {
     std::ofstream output(filename, std::ios::binary);
     if (!output.is_open())
         return false;
@@ -45,7 +45,7 @@ bool files::write_bytes(fs::path filename, const ubyte* data, size_t size) {
     return true;
 }
 
-uint files::append_bytes(fs::path filename, const ubyte* data, size_t size) {
+uint files::append_bytes(const fs::path& filename, const ubyte* data, size_t size) {
     std::ofstream output(filename, std::ios::binary | std::ios::app);
     if (!output.is_open())
         return 0;
@@ -55,7 +55,7 @@ uint files::append_bytes(fs::path filename, const ubyte* data, size_t size) {
     return position;
 }
 
-bool files::read(fs::path filename, char* data, size_t size) {
+bool files::read(const fs::path& filename, char* data, size_t size) {
     std::ifstream output(filename, std::ios::binary);
     if (!output.is_open())
         return false;
@@ -64,7 +64,7 @@ bool files::read(fs::path filename, char* data, size_t size) {
     return true;
 }
 
-std::unique_ptr<ubyte[]> files::read_bytes(fs::path filename, size_t& length) {
+std::unique_ptr<ubyte[]> files::read_bytes(const fs::path& filename, size_t& length) {
     std::ifstream input(filename, std::ios::binary);
     if (!input.is_open())
         return nullptr;
@@ -78,7 +78,7 @@ std::unique_ptr<ubyte[]> files::read_bytes(fs::path filename, size_t& length) {
     return data;
 }
 
-std::string files::read_string(fs::path filename) {
+std::string files::read_string(const fs::path& filename) {
     size_t size;
     std::unique_ptr<ubyte[]> bytes (read_bytes(filename, size));
     if (bytes == nullptr) {
@@ -88,7 +88,7 @@ std::string files::read_string(fs::path filename) {
     return std::string((const char*)bytes.get(), size);
 }
 
-bool files::write_string(fs::path filename, const std::string content) {
+bool files::write_string(const fs::path& filename, const std::string content) {
     std::ofstream file(filename);
     if (!file) {
         return false;
@@ -97,16 +97,16 @@ bool files::write_string(fs::path filename, const std::string content) {
     return true;
 }
 
-bool files::write_json(fs::path filename, const dynamic::Map* obj, bool nice) {
+bool files::write_json(const fs::path& filename, const dynamic::Map* obj, bool nice) {
     return files::write_string(filename, json::stringify(obj, nice, "  "));
 }
 
-bool files::write_binary_json(fs::path filename, const dynamic::Map* obj, bool compression) {
+bool files::write_binary_json(const fs::path& filename, const dynamic::Map* obj, bool compression) {
     auto bytes = json::to_binary(obj, compression);
     return files::write_bytes(filename, bytes.data(), bytes.size());
 }
 
-std::shared_ptr<dynamic::Map> files::read_json(fs::path filename) {
+std::shared_ptr<dynamic::Map> files::read_json(const fs::path& filename) {
     std::string text = files::read_string(filename);
     try {
         return json::parse(filename.string(), text);;
@@ -116,17 +116,17 @@ std::shared_ptr<dynamic::Map> files::read_json(fs::path filename) {
     }
 }
 
-std::shared_ptr<dynamic::Map> files::read_binary_json(fs::path file) {
+std::shared_ptr<dynamic::Map> files::read_binary_json(const fs::path& file) {
     size_t size;
     std::unique_ptr<ubyte[]> bytes (files::read_bytes(file, size));
     return json::from_binary(bytes.get(), size);
 }
 
-std::shared_ptr<dynamic::Map> files::read_toml(fs::path file) {
+std::shared_ptr<dynamic::Map> files::read_toml(const fs::path& file) {
     return toml::parse(file.u8string(), files::read_string(file));
 }
 
-std::vector<std::string> files::read_list(fs::path filename) {
+std::vector<std::string> files::read_list(const fs::path& filename) {
     std::ifstream file(filename);
     if (!file) {
         throw std::runtime_error("could not to open file "+filename.u8string());

--- a/src/files/files.hpp
+++ b/src/files/files.hpp
@@ -20,7 +20,7 @@ namespace files {
         std::ifstream file;
         size_t filelength;
     public:
-        rafile(fs::path filename);
+        rafile(const fs::path& filename);
 
         void seekg(std::streampos pos);
         void read(char* buffer, std::streamsize size);
@@ -31,40 +31,40 @@ namespace files {
     /// @param file target file
     /// @param data data bytes array
     /// @param size size of data bytes array
-    bool write_bytes(fs::path file, const ubyte* data, size_t size);
+    bool write_bytes(const fs::path& file, const ubyte* data, size_t size);
 
     /// @brief Append bytes array to the file without any extra data
     /// @param file target file
     /// @param data data bytes array
     /// @param size size of data bytes array
-    uint append_bytes(fs::path file, const ubyte* data, size_t size);
+    uint append_bytes(const fs::path& file, const ubyte* data, size_t size);
 
     /// @brief Write string to the file
-    bool write_string(fs::path filename, const std::string content);
+    bool write_string(const fs::path& filename, const std::string content);
 
     /// @brief Write dynamic data to the JSON file
     /// @param nice if true, human readable format will be used, otherwise minimal
-    bool write_json(fs::path filename, const dynamic::Map* obj, bool nice=true);
+    bool write_json(const fs::path& filename, const dynamic::Map* obj, bool nice=true);
 
     /// @brief Write dynamic data to the binary JSON file
     /// (see src/coders/binary_json_spec.md)
     /// @param compressed use gzip compression
     bool write_binary_json(
-        fs::path filename, 
+        const fs::path& filename,
         const dynamic::Map* obj, 
         bool compressed=false
     );
 
-    bool read(fs::path, char* data, size_t size);
-    std::unique_ptr<ubyte[]> read_bytes(fs::path, size_t& length);
-    std::string read_string(fs::path filename);
+    bool read(const fs::path&, char* data, size_t size);
+    std::unique_ptr<ubyte[]> read_bytes(const fs::path&, size_t& length);
+    std::string read_string(const fs::path& filename);
 
     /// @brief Read JSON or BJSON file
     /// @param file *.json or *.bjson file
-    std::shared_ptr<dynamic::Map> read_json(fs::path file);
-    std::shared_ptr<dynamic::Map> read_binary_json(fs::path file);
-    std::shared_ptr<dynamic::Map> read_toml(fs::path file);
-    std::vector<std::string> read_list(fs::path file);
+    std::shared_ptr<dynamic::Map> read_json(const fs::path& file);
+    std::shared_ptr<dynamic::Map> read_binary_json(const fs::path& file);
+    std::shared_ptr<dynamic::Map> read_toml(const fs::path& file);
+    std::vector<std::string> read_list(const fs::path& file);
 }
 
 #endif /* FILES_FILES_HPP_ */

--- a/src/files/settings_io.cpp
+++ b/src/files/settings_io.cpp
@@ -8,6 +8,7 @@
 #include "../settings.hpp"
 
 #include <memory>
+#include <utility>
 
 static debug::Logger logger("settings_io");
 
@@ -22,10 +23,10 @@ struct SectionsBuilder {
     }
 
     void section(std::string name) {
-        sections.push_back(Section {name, {}});
+        sections.push_back(Section {std::move(name), {}});
     }
 
-    void add(std::string name, Setting* setting, bool writeable=true) {
+    void add(const std::string& name, Setting* setting, bool writeable=true) {
         Section& section = sections.at(sections.size()-1);
         map[section.name+"."+name] = setting;
         section.keys.push_back(name);

--- a/src/frontend/UiDocument.cpp
+++ b/src/frontend/UiDocument.cpp
@@ -1,5 +1,7 @@
 #include "UiDocument.hpp"
 
+#include <utility>
+
 #include "../files/files.hpp"
 #include "../graphics/ui/elements/UINode.hpp"
 #include "../graphics/ui/elements/InventoryView.hpp"
@@ -9,9 +11,9 @@
 UiDocument::UiDocument(
     std::string id, 
     uidocscript script, 
-    std::shared_ptr<gui::UINode> root,
+    const std::shared_ptr<gui::UINode>& root,
     scriptenv env
-) : id(id), script(script), root(root), env(env) {
+) : id(std::move(id)), script(script), root(root), env(std::move(env)) {
     gui::UINode::getIndices(root, map);
 }
 
@@ -51,7 +53,7 @@ scriptenv UiDocument::getEnvironment() const {
     return env;
 }
 
-std::unique_ptr<UiDocument> UiDocument::read(scriptenv penv, std::string name, fs::path file) {
+std::unique_ptr<UiDocument> UiDocument::read(const scriptenv& penv, const std::string& name, const fs::path& file) {
     const std::string text = files::read_string(file);
     auto xmldoc = xml::parse(file.u8string(), text);
 
@@ -72,7 +74,7 @@ std::unique_ptr<UiDocument> UiDocument::read(scriptenv penv, std::string name, f
     return std::make_unique<UiDocument>(name, script, view, env);
 }
 
-std::shared_ptr<gui::UINode> UiDocument::readElement(fs::path file) {
+std::shared_ptr<gui::UINode> UiDocument::readElement(const fs::path& file) {
     auto document = read(nullptr, file.filename().u8string(), file);
     return document->getRoot();
 }

--- a/src/frontend/UiDocument.hpp
+++ b/src/frontend/UiDocument.hpp
@@ -32,7 +32,7 @@ public:
     UiDocument(
         std::string id, 
         uidocscript script, 
-        std::shared_ptr<gui::UINode> root, 
+        const std::shared_ptr<gui::UINode> &root,
         scriptenv env
     );
 
@@ -46,8 +46,8 @@ public:
     const uidocscript& getScript() const;
     scriptenv getEnvironment() const;
 
-    static std::unique_ptr<UiDocument> read(scriptenv parent_env, std::string name, fs::path file);
-    static std::shared_ptr<gui::UINode> readElement(fs::path file);
+    static std::unique_ptr<UiDocument> read(const scriptenv& parent_env, const std::string& name, const fs::path& file);
+    static std::shared_ptr<gui::UINode> readElement(const fs::path& file);
 };
 
 #endif // FRONTEND_UI_DOCUMENT_HPP_

--- a/src/frontend/debug_panel.cpp
+++ b/src/frontend/debug_panel.cpp
@@ -21,12 +21,13 @@
 #include <memory>
 #include <sstream>
 #include <bitset>
+#include <utility>
 
 using namespace gui;
 
 static std::shared_ptr<Label> create_label(wstringsupplier supplier) {
     auto label = std::make_shared<Label>(L"-");
-    label->textSupplier(supplier);
+    label->textSupplier(std::move(supplier));
     return label;
 }
 
@@ -75,13 +76,13 @@ std::shared_ptr<UINode> create_debug_panel(
     panel->add(create_label([=](){
         std::wstringstream stream;
         stream << "r:" << player->selectedVoxel.state.rotation << " s:"
-               << player->selectedVoxel.state.segment << " u:"
-               << std::bitset<8>(player->selectedVoxel.state.userbits);
+                << player->selectedVoxel.state.segment << " u:"
+                << std::bitset<8>(player->selectedVoxel.state.userbits);
         if (player->selectedVoxel.id == BLOCK_VOID) {
             return std::wstring {L"block: -"};
         } else {
             return L"block: "+std::to_wstring(player->selectedVoxel.id)+
-                L" "+stream.str();
+                   L" "+stream.str();
         }
     }));
     panel->add(create_label([=](){
@@ -114,7 +115,7 @@ std::shared_ptr<UINode> create_debug_panel(
             Hitbox* hitbox = player->hitbox.get();
             return util::to_wstring(hitbox->position[ax], 2);
         });
-        box->setTextConsumer([=](std::wstring text) {
+        box->setTextConsumer([=](const std::wstring& text) {
             try {
                 glm::vec3 position = player->hitbox->position;
                 position[ax] = std::stoi(text);
@@ -137,8 +138,8 @@ std::shared_ptr<UINode> create_debug_panel(
         timeutil::from_value(level->getWorld()->daytime, hour, minute, second);
 
         std::wstring timeString = 
-                     util::lfill(std::to_wstring(hour), 2, L'0') + L":" +
-                     util::lfill(std::to_wstring(minute), 2, L'0');
+                util::lfill(std::to_wstring(hour), 2, L'0') + L":" +
+                util::lfill(std::to_wstring(minute), 2, L'0');
         return L"time: "+timeString;
     }));
     {

--- a/src/frontend/hud.cpp
+++ b/src/frontend/hud.cpp
@@ -48,6 +48,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 using namespace gui;
 
@@ -63,7 +64,7 @@ HudElement::HudElement(
     UiDocument* document, 
     std::shared_ptr<UINode> node, 
     bool debug
-) : mode(mode), document(document), node(node), debug(debug) {
+) : mode(mode), document(document), node(std::move(node)), debug(debug) {
 }
 
 void HudElement::update(bool pause, bool inventoryOpen, bool debugMode) {
@@ -398,7 +399,7 @@ void Hud::closeInventory() {
     cleanup();
 }
 
-void Hud::add(HudElement element) {
+void Hud::add(const HudElement& element) {
     using namespace dynamic;
 
     gui->add(element.getNode());
@@ -435,7 +436,7 @@ void Hud::onRemove(const HudElement& element) {
     gui->remove(element.getNode());
 }
 
-void Hud::remove(std::shared_ptr<UINode> node) {
+void Hud::remove(const std::shared_ptr<UINode>& node) {
     for (auto& element : elements) {
         if (element.getNode() == node) {
             element.setRemoved();

--- a/src/frontend/hud.hpp
+++ b/src/frontend/hud.hpp
@@ -161,9 +161,9 @@ public:
     /// @param doc element layout
     void openPermanent(UiDocument* doc);
 
-    void add(HudElement element);
+    void add(const HudElement& element);
     void onRemove(const HudElement& element);
-    void remove(std::shared_ptr<gui::UINode> node);
+    void remove(const std::shared_ptr<gui::UINode>& node);
 
     Player* getPlayer() const;
 

--- a/src/frontend/locale.cpp
+++ b/src/frontend/locale.cpp
@@ -1,5 +1,7 @@
 #include "locale.hpp"
 
+#include <utility>
+
 #include "../coders/json.hpp"
 #include "../coders/commons.hpp"
 #include "../content/ContentPack.hpp"
@@ -16,7 +18,7 @@ using namespace std::literals;
 std::unique_ptr<langs::Lang> langs::current;
 std::unordered_map<std::string, langs::LocaleInfo> langs::locales_info;
 
-langs::Lang::Lang(std::string locale) : locale(locale) {
+langs::Lang::Lang(std::string locale) : locale(std::move(locale)) {
 }
 
 const std::wstring& langs::Lang::get(const std::wstring& key) const  {
@@ -50,7 +52,7 @@ public:
     Reader(std::string_view file, std::string_view source) : BasicParser(file, source) {
     }
 
-    void read(langs::Lang& lang, std::string prefix) {
+    void read(langs::Lang& lang, const std::string &prefix) {
         skipWhitespace();
         while (hasNext()) {
             std::string key = parseString('=', true);

--- a/src/frontend/menu.cpp
+++ b/src/frontend/menu.cpp
@@ -88,7 +88,7 @@ UiDocument* menus::show(Engine* engine, const std::string& name, std::vector<dyn
     return document;
 }
 
-void menus::show_process_panel(Engine* engine, std::shared_ptr<Task> task, std::wstring text) {
+void menus::show_process_panel(Engine* engine, const std::shared_ptr<Task>& task, const std::wstring& text) {
     using namespace dynamic;
     
     uint initialWork = task->getWorkTotal();

--- a/src/frontend/menu.hpp
+++ b/src/frontend/menu.hpp
@@ -25,7 +25,7 @@ namespace menus {
         std::vector<dynamic::Value> args
     );
 
-    void show_process_panel(Engine* engine, std::shared_ptr<Task> task, std::wstring text=L"");
+    void show_process_panel(Engine* engine, const std::shared_ptr<Task>& task, const std::wstring& text=L"");
 }
 
 #endif // FRONTEND_MENU_MENU_HPP_

--- a/src/graphics/core/Atlas.cpp
+++ b/src/graphics/core/Atlas.cpp
@@ -42,7 +42,7 @@ ImageData* Atlas::getImage() const {
     return image.get();
 }
 
-void AtlasBuilder::add(std::string name, std::unique_ptr<ImageData> image) {
+void AtlasBuilder::add(const std::string& name, std::unique_ptr<ImageData> image) {
     entries.push_back(atlasentry{name, std::shared_ptr<ImageData>(image.release())});
     names.insert(name);
 }

--- a/src/graphics/core/Atlas.hpp
+++ b/src/graphics/core/Atlas.hpp
@@ -46,7 +46,7 @@ class AtlasBuilder {
     std::set<std::string> names;
 public:
     AtlasBuilder() {}
-    void add(std::string name, std::unique_ptr<ImageData> image);
+    void add(const std::string& name, std::unique_ptr<ImageData> image);
     bool has(const std::string& name) const;
     const std::set<std::string>& getNames() { return names; };
 

--- a/src/graphics/core/DrawContext.cpp
+++ b/src/graphics/core/DrawContext.cpp
@@ -2,6 +2,8 @@
 
 #include <GL/glew.h>
 
+#include <utility>
+
 #include "Batch2D.hpp"
 #include "Framebuffer.hpp"
 #include "../../window/Window.hpp"
@@ -23,10 +25,10 @@ static void set_blend_mode(BlendMode mode) {
 
 DrawContext::DrawContext(
     const DrawContext* parent, 
-    const Viewport& viewport, 
+    Viewport  viewport,
     Batch2D* g2d
 ) : parent(parent), 
-    viewport(viewport), 
+    viewport(std::move(viewport)),
     g2d(g2d) 
 {}
 

--- a/src/graphics/core/DrawContext.hpp
+++ b/src/graphics/core/DrawContext.hpp
@@ -19,7 +19,7 @@ class DrawContext {
     BlendMode blendMode = BlendMode::normal;
     int scissorsCount = 0;
 public:
-    DrawContext(const DrawContext* parent, const Viewport& viewport, Batch2D* g2d);
+    DrawContext(const DrawContext* parent, Viewport  viewport, Batch2D* g2d);
     ~DrawContext();
     
     Batch2D* getBatch2D() const;

--- a/src/graphics/core/Font.cpp
+++ b/src/graphics/core/Font.cpp
@@ -1,4 +1,6 @@
 #include "Font.hpp"
+
+#include <utility>
 #include "Texture.hpp"
 #include "Batch2D.hpp"
 
@@ -43,7 +45,7 @@ int Font::calcWidth(const std::wstring& text, size_t offset, size_t length) {
 }
 
 void Font::draw(Batch2D* batch, std::wstring text, int x, int y) {
-    draw(batch, text, x, y, FontStyle::none);
+    draw(batch, std::move(text), x, y, FontStyle::none);
 }
 
 static inline void drawGlyph(Batch2D* batch, int x, int y, uint c, FontStyle style) {
@@ -66,7 +68,7 @@ static inline void drawGlyph(Batch2D* batch, int x, int y, uint c, FontStyle sty
     batch->sprite(x, y, GLYPH_SIZE, GLYPH_SIZE, 16, c, batch->getColor());
 }
 
-void Font::draw(Batch2D* batch, std::wstring text, int x, int y, FontStyle style) {
+void Font::draw(Batch2D* batch, const std::wstring& text, int x, int y, FontStyle style) {
     draw(batch, std::wstring_view(text.c_str(), text.length()), x, y, style);
 }
 

--- a/src/graphics/core/Font.hpp
+++ b/src/graphics/core/Font.hpp
@@ -43,7 +43,7 @@ public:
     /// @param codepoint character unicode codepoint
     bool isPrintableChar(uint codepoint) const;
     void draw(Batch2D* batch, std::wstring text, int x, int y);
-    void draw(Batch2D* batch, std::wstring text, int x, int y, FontStyle style);
+    void draw(Batch2D* batch, const std::wstring& text, int x, int y, FontStyle style);
     void draw(Batch2D* batch, std::wstring_view text, int x, int y, FontStyle style);
 };
 

--- a/src/graphics/render/ChunksRenderer.cpp
+++ b/src/graphics/render/ChunksRenderer.cpp
@@ -55,7 +55,7 @@ ChunksRenderer::ChunksRenderer(
 ChunksRenderer::~ChunksRenderer() {
 }
 
-std::shared_ptr<Mesh> ChunksRenderer::render(std::shared_ptr<Chunk> chunk, bool important) {
+std::shared_ptr<Mesh> ChunksRenderer::render(const std::shared_ptr<Chunk>& chunk, bool important) {
     chunk->flags.modified = false;
     if (important) {
         auto mesh = renderer->render(chunk.get(), level->chunksStorage.get());
@@ -78,7 +78,7 @@ void ChunksRenderer::unload(const Chunk* chunk) {
     }
 }
 
-std::shared_ptr<Mesh> ChunksRenderer::getOrRender(std::shared_ptr<Chunk> chunk, bool important) {
+std::shared_ptr<Mesh> ChunksRenderer::getOrRender(const std::shared_ptr<Chunk>& chunk, bool important) {
     auto found = meshes.find(glm::ivec2(chunk->x, chunk->z));
     if (found == meshes.end()) {
         return render(chunk, important);

--- a/src/graphics/render/ChunksRenderer.hpp
+++ b/src/graphics/render/ChunksRenderer.hpp
@@ -38,10 +38,10 @@ public:
     );
     virtual ~ChunksRenderer();
 
-    std::shared_ptr<Mesh> render(std::shared_ptr<Chunk> chunk, bool important);
+    std::shared_ptr<Mesh> render(const std::shared_ptr<Chunk>& chunk, bool important);
     void unload(const Chunk* chunk);
 
-    std::shared_ptr<Mesh> getOrRender(std::shared_ptr<Chunk> chunk, bool important);
+    std::shared_ptr<Mesh> getOrRender(const std::shared_ptr<Chunk>& chunk, bool important);
     std::shared_ptr<Mesh> get(Chunk* chunk);
 
     void update();

--- a/src/graphics/ui/GUI.cpp
+++ b/src/graphics/ui/GUI.cpp
@@ -19,6 +19,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <utility>
 
 using namespace gui;
 
@@ -221,18 +222,18 @@ bool GUI::isFocusCaught() const {
 }
 
 void GUI::add(std::shared_ptr<UINode> node) {
-    container->add(node);
+    container->add(std::move(node));
 }
 
 void GUI::remove(std::shared_ptr<UINode> node) noexcept {
-    container->remove(node);
+    container->remove(std::move(node));
 }
 
-void GUI::store(std::string name, std::shared_ptr<UINode> node) {
-    storage[name] = node;
+void GUI::store(const std::string& name, std::shared_ptr<UINode> node) {
+    storage[name] = std::move(node);
 }
 
-std::shared_ptr<UINode> GUI::get(std::string name) noexcept {
+std::shared_ptr<UINode> GUI::get(const std::string& name) noexcept {
     auto found = storage.find(name);
     if (found == storage.end()) {
         return nullptr;
@@ -240,7 +241,7 @@ std::shared_ptr<UINode> GUI::get(std::string name) noexcept {
     return found->second;
 }
 
-void GUI::remove(std::string name) noexcept {
+void GUI::remove(const std::string& name) noexcept {
     storage.erase(name);
 }
 
@@ -248,7 +249,7 @@ void GUI::setFocus(std::shared_ptr<UINode> node) {
     if (focus) {
         focus->defocus();
     }
-    focus = node;
+    focus = std::move(node);
     if (focus) {
         focus->onFocus(this);
     }
@@ -258,7 +259,7 @@ std::shared_ptr<Container> GUI::getContainer() const {
     return container;
 }
 
-void GUI::postRunnable(runnable callback) {
+void GUI::postRunnable(const runnable& callback) {
     postRunnables.push(callback);
 }
 

--- a/src/graphics/ui/GUI.hpp
+++ b/src/graphics/ui/GUI.hpp
@@ -108,16 +108,16 @@ namespace gui {
         /// (does not add node to the main container)
         /// @param name node key
         /// @param node target node
-        void store(std::string name, std::shared_ptr<UINode> node);
+        void store(const std::string& name, std::shared_ptr<UINode> node);
 
         /// @brief Get node from the GUI nodes dictionary 
         /// @param name node key
         /// @return stored node or nullptr
-        std::shared_ptr<UINode> get(std::string name) noexcept;
+        std::shared_ptr<UINode> get(const std::string& name) noexcept;
 
         /// @brief Remove node from the GUI nodes dictionary
         /// @param name node key 
-        void remove(std::string name) noexcept;
+        void remove(const std::string& name) noexcept;
 
         /// @brief Set node as focused 
         /// @param node new focused node or nullptr to remove focus
@@ -129,7 +129,7 @@ namespace gui {
 
         void onAssetsLoad(Assets* assets);
 
-        void postRunnable(runnable callback);
+        void postRunnable(const runnable& callback);
 
         void setDoubleClickDelay(float delay);
         float getDoubleClickDelay() const;

--- a/src/graphics/ui/elements/Button.cpp
+++ b/src/graphics/ui/elements/Button.cpp
@@ -1,12 +1,14 @@
 #include "Button.hpp"
 
+#include <utility>
+
 #include "Label.hpp"
 #include "../../core/DrawContext.hpp"
 #include "../../core/Batch2D.hpp"
 
 using namespace gui;
 
-Button::Button(std::shared_ptr<UINode> content, glm::vec4 padding)
+Button::Button(const std::shared_ptr<UINode>& content, glm::vec4 padding)
     : Panel(glm::vec2(), padding, 0) {
     glm::vec4 margin = getMargin();
     setSize(content->getSize()+
@@ -20,9 +22,9 @@ Button::Button(std::shared_ptr<UINode> content, glm::vec4 padding)
 }
 
 Button::Button(
-    std::wstring text, 
+    const std::wstring& text,
     glm::vec4 padding, 
-    onaction action,
+    const onaction& action,
     glm::vec2 size
 ) : Panel(size, padding, 0) 
 {
@@ -63,7 +65,7 @@ std::wstring Button::getText() const {
 
 Button* Button::textSupplier(wstringsupplier supplier) {
     if (label) {
-        label->textSupplier(supplier);
+        label->textSupplier(std::move(supplier));
     }
     return this;
 }

--- a/src/graphics/ui/elements/Button.hpp
+++ b/src/graphics/ui/elements/Button.hpp
@@ -10,12 +10,12 @@ namespace gui {
     protected:
         std::shared_ptr<Label> label = nullptr;
     public:
-        Button(std::shared_ptr<UINode> content, 
+        Button(const std::shared_ptr<UINode>& content,
                glm::vec4 padding=glm::vec4(2.0f));
                
-        Button(std::wstring text, 
+        Button(const std::wstring& text,
                glm::vec4 padding,
-               onaction action,
+               const onaction& action,
                glm::vec2 size=glm::vec2(-1));
 
         virtual void drawBackground(const DrawContext* pctx, Assets* assets) override;

--- a/src/graphics/ui/elements/CheckBox.cpp
+++ b/src/graphics/ui/elements/CheckBox.cpp
@@ -1,5 +1,7 @@
 #include "CheckBox.hpp"
 
+#include <utility>
+
 #include "../../core/DrawContext.hpp"
 #include "../../core/Batch2D.hpp"
 #include "Label.hpp"
@@ -30,11 +32,11 @@ void CheckBox::mouseRelease(GUI*, int, int) {
 }
 
 void CheckBox::setSupplier(boolsupplier supplier) {
-    this->supplier = supplier;
+    this->supplier = std::move(supplier);
 }
 
 void CheckBox::setConsumer(boolconsumer consumer) {
-    this->consumer = consumer;
+    this->consumer = std::move(consumer);
 }
 
 CheckBox* CheckBox::setChecked(bool flag) {
@@ -42,7 +44,7 @@ CheckBox* CheckBox::setChecked(bool flag) {
     return this;
 }
 
-FullCheckBox::FullCheckBox(std::wstring text, glm::vec2 size, bool checked)
+FullCheckBox::FullCheckBox(const std::wstring& text, glm::vec2 size, bool checked)
     : Panel(size), 
       checkbox(std::make_shared<CheckBox>(checked)){
     setColor(glm::vec4(0.0f));

--- a/src/graphics/ui/elements/CheckBox.hpp
+++ b/src/graphics/ui/elements/CheckBox.hpp
@@ -1,6 +1,8 @@
 #ifndef GRAPHICS_UI_ELEMENTS_CHECKBOX_HPP_
 #define GRAPHICS_UI_ELEMENTS_CHECKBOX_HPP_
 
+#include <utility>
+
 #include "Panel.hpp"
 
 namespace gui {
@@ -33,14 +35,14 @@ namespace gui {
     protected:
         std::shared_ptr<CheckBox> checkbox;
     public:
-        FullCheckBox(std::wstring text, glm::vec2 size, bool checked=false);
+        FullCheckBox(const std::wstring& text, glm::vec2 size, bool checked=false);
 
         virtual void setSupplier(boolsupplier supplier) {
-            checkbox->setSupplier(supplier);
+            checkbox->setSupplier(std::move(supplier));
         }
 
         virtual void setConsumer(boolconsumer consumer) {
-            checkbox->setConsumer(consumer);
+            checkbox->setConsumer(std::move(consumer));
         }
 
         virtual void setChecked(bool flag) {

--- a/src/graphics/ui/elements/Container.cpp
+++ b/src/graphics/ui/elements/Container.cpp
@@ -4,6 +4,7 @@
 #include "../../core/Batch2D.hpp"
 
 #include <algorithm>
+#include <utility>
 
 using namespace gui;
 
@@ -31,7 +32,7 @@ std::shared_ptr<UINode> Container::getAt(glm::vec2 pos, std::shared_ptr<UINode> 
 }
 
 void Container::act(float delta) {
-    for (auto node : nodes) {
+    for (const auto& node : nodes) {
         if (node->isVisible()) {
             node->act(delta);
         }
@@ -86,7 +87,7 @@ void Container::draw(const DrawContext* pctx, Assets* assets) {
     {
         DrawContext ctx = pctx->sub();
         ctx.setScissors(glm::vec4(pos.x, pos.y, size.x, size.y));
-        for (auto node : nodes) {
+        for (const auto& node : nodes) {
             if (node->isVisible())
                 node->draw(pctx, assets);
         }
@@ -105,22 +106,22 @@ void Container::drawBackground(const DrawContext* pctx, Assets*) {
     batch->rect(pos.x, pos.y, size.x, size.y);
 }
 
-void Container::add(std::shared_ptr<UINode> node) {
+void Container::add(const std::shared_ptr<UINode> &node) {
     nodes.push_back(node);
     node->setParent(this);
     node->reposition();
     refresh();
 }
 
-void Container::add(std::shared_ptr<UINode> node, glm::vec2 pos) {
+void Container::add(const std::shared_ptr<UINode>& node, glm::vec2 pos) {
     node->setPos(pos);
     add(node);
 }
 
-void Container::remove(std::shared_ptr<UINode> selected) {
+void Container::remove(const std::shared_ptr<UINode>& selected) {
     selected->setParent(nullptr);
     nodes.erase(std::remove_if(nodes.begin(), nodes.end(), 
-        [selected](const std::shared_ptr<UINode> node) {
+        [selected](const std::shared_ptr<UINode>& node) {
             return node == selected;
         }
     ), nodes.end());
@@ -136,7 +137,7 @@ void Container::remove(const std::string& id) {
 }
 
 void Container::clear() {
-    for (auto node : nodes) {
+    for (const auto& node : nodes) {
         node->setParent(nullptr);
     }
     nodes.clear();
@@ -144,7 +145,7 @@ void Container::clear() {
 }
 
 void Container::listenInterval(float interval, ontimeout callback, int repeat) {
-    intervalEvents.push_back({callback, interval, 0.0f, repeat});
+    intervalEvents.push_back({std::move(callback), interval, 0.0f, repeat});
 }
 
 void Container::setSize(glm::vec2 size) {

--- a/src/graphics/ui/elements/Container.hpp
+++ b/src/graphics/ui/elements/Container.hpp
@@ -22,10 +22,10 @@ namespace gui {
         virtual void drawBackground(const DrawContext* pctx, Assets* assets);
         virtual void draw(const DrawContext* pctx, Assets* assets) override;
         virtual std::shared_ptr<UINode> getAt(glm::vec2 pos, std::shared_ptr<UINode> self) override;
-        virtual void add(std::shared_ptr<UINode> node);
-        virtual void add(std::shared_ptr<UINode> node, glm::vec2 pos);
+        virtual void add(const std::shared_ptr<UINode> &node);
+        virtual void add(const std::shared_ptr<UINode> &node, glm::vec2 pos);
         virtual void clear();
-        virtual void remove(std::shared_ptr<UINode> node);
+        virtual void remove(const std::shared_ptr<UINode>& node);
         virtual void remove(const std::string& id);
         virtual void scrolled(int value) override;
         virtual void setScrollable(bool flag);

--- a/src/graphics/ui/elements/Image.cpp
+++ b/src/graphics/ui/elements/Image.cpp
@@ -1,5 +1,7 @@
 #include "Image.hpp"
 
+#include <utility>
+
 #include "../../core/DrawContext.hpp"
 #include "../../core/Batch2D.hpp"
 #include "../../core/Texture.hpp"
@@ -8,7 +10,7 @@
 
 using namespace gui;
 
-Image::Image(std::string texture, glm::vec2 size) : UINode(size), texture(texture) {
+Image::Image(std::string texture, glm::vec2 size) : UINode(size), texture(std::move(texture)) {
     setInteractive(false);
 }
 

--- a/src/graphics/ui/elements/InventoryView.cpp
+++ b/src/graphics/ui/elements/InventoryView.cpp
@@ -25,6 +25,7 @@
 #include "../GUI.hpp"
 
 #include <glm/glm.hpp>
+#include <utility>
 
 using namespace gui;
 
@@ -40,9 +41,9 @@ SlotLayout::SlotLayout(
     position(position),
     background(background),
     itemSource(itemSource),
-    updateFunc(updateFunc),
-    shareFunc(shareFunc),
-    rightClick(rightClick) {}
+    updateFunc(std::move(updateFunc)),
+    shareFunc(std::move(shareFunc)),
+    rightClick(std::move(rightClick)) {}
 
 InventoryBuilder::InventoryBuilder() {
     view = std::make_shared<InventoryView>();
@@ -53,7 +54,7 @@ void InventoryBuilder::addGrid(
     glm::vec2 pos, 
     int padding,
     bool addpanel,
-    SlotLayout slotLayout
+    const SlotLayout& slotLayout
 ) {
     const int slotSize = InventoryView::SLOT_SIZE;
     const int interval = InventoryView::SLOT_INTERVAL;
@@ -95,7 +96,7 @@ void InventoryBuilder::addGrid(
     }
 }
 
-void InventoryBuilder::add(SlotLayout layout) {
+void InventoryBuilder::add(const SlotLayout& layout) {
     view->add(view->addSlot(layout), layout.position);
 }
 
@@ -106,7 +107,7 @@ std::shared_ptr<InventoryView> InventoryBuilder::build() {
 SlotView::SlotView(
     SlotLayout layout
 ) : UINode(glm::vec2(InventoryView::SLOT_SIZE)),
-    layout(layout)
+    layout(std::move(layout))
 {
     setColor(glm::vec4(0, 0, 0, 0.2f));
     setTooltipDelay(0.05f);
@@ -309,7 +310,7 @@ InventoryView::InventoryView() : Container(glm::vec2()) {
 InventoryView::~InventoryView() {}
 
 
-std::shared_ptr<SlotView> InventoryView::addSlot(SlotLayout layout) {
+std::shared_ptr<SlotView> InventoryView::addSlot(const SlotLayout& layout) {
     uint width =  InventoryView::SLOT_SIZE + layout.padding;
     uint height = InventoryView::SLOT_SIZE + layout.padding;
 
@@ -341,7 +342,7 @@ size_t InventoryView::getSlotsCount() const {
 }
 
 void InventoryView::bind(
-    std::shared_ptr<Inventory> inventory,
+    const std::shared_ptr<Inventory>& inventory,
     const Content* content
 ) {
     this->inventory = inventory;

--- a/src/graphics/ui/elements/InventoryView.hpp
+++ b/src/graphics/ui/elements/InventoryView.hpp
@@ -96,13 +96,13 @@ namespace gui {
         void setSelected(int index);
 
         void bind(
-            std::shared_ptr<Inventory> inventory,
+            const std::shared_ptr<Inventory>& inventory,
             const Content* content
         );
         
         void unbind();
 
-        std::shared_ptr<SlotView> addSlot(SlotLayout layout);
+        std::shared_ptr<SlotView> addSlot(const SlotLayout& layout);
 
         std::shared_ptr<Inventory> getInventory() const;
 
@@ -130,10 +130,10 @@ namespace gui {
             glm::vec2 pos, 
             int padding,
             bool addpanel,
-            SlotLayout slotLayout
+            const SlotLayout& slotLayout
         );
         
-        void add(SlotLayout slotLayout);
+        void add(const SlotLayout& slotLayout);
         std::shared_ptr<InventoryView> build();
     };
 }

--- a/src/graphics/ui/elements/Label.cpp
+++ b/src/graphics/ui/elements/Label.cpp
@@ -1,4 +1,6 @@
 #include "Label.hpp"
+
+#include <utility>
 #include "../../core/DrawContext.hpp"
 #include "../../core/Batch2D.hpp"
 #include "../../core/Font.hpp"
@@ -45,20 +47,20 @@ void LabelCache::update(const std::wstring& text, bool multiline, bool wrap) {
     }
 }
 
-Label::Label(std::string text, std::string fontName) 
+Label::Label(const std::string& text, std::string fontName)
   : UINode(glm::vec2(text.length() * 8, 15)),
     text(util::str2wstr_utf8(text)), 
-    fontName(fontName) 
+    fontName(std::move(fontName))
 {
     setInteractive(false);
     cache.update(this->text, multiline, textWrap);
 }
 
 
-Label::Label(std::wstring text, std::string fontName) 
+Label::Label(const std::wstring& text, std::string fontName)
   : UINode(glm::vec2(text.length() * 8, 15)), 
     text(text), 
-    fontName(fontName) 
+    fontName(std::move(fontName))
 {
     setInteractive(false);
     cache.update(this->text, multiline, textWrap);
@@ -76,7 +78,7 @@ glm::vec2 Label::calcSize() {
     );
 }
 
-void Label::setText(std::wstring text) {
+void Label::setText(const std::wstring& text) {
     if (text == this->text && !cache.resetFlag) {
         return;
     }
@@ -93,7 +95,7 @@ const std::wstring& Label::getText() const {
 }
 
 void Label::setFontName(std::string name) {
-    this->fontName = name;
+    this->fontName = std::move(name);
 }
 
 const std::string& Label::getFontName() const {
@@ -207,7 +209,7 @@ void Label::draw(const DrawContext* pctx, Assets* assets) {
 }
 
 void Label::textSupplier(wstringsupplier supplier) {
-    this->supplier = supplier;
+    this->supplier = std::move(supplier);
 }
 
 void Label::setAutoResize(bool flag) {

--- a/src/graphics/ui/elements/Label.hpp
+++ b/src/graphics/ui/elements/Label.hpp
@@ -53,10 +53,10 @@ namespace gui {
         /// @brief Auto resize label to fit text
         bool autoresize = false;
     public:
-        Label(std::string text, std::string fontName="normal");
-        Label(std::wstring text, std::string fontName="normal");
+        Label(const std::string& text, std::string fontName="normal");
+        Label(const std::wstring& text, std::string fontName="normal");
 
-        virtual void setText(std::wstring text);
+        virtual void setText(const std::wstring& text);
         const std::wstring& getText() const;
 
         virtual void setFontName(std::string name);

--- a/src/graphics/ui/elements/Menu.cpp
+++ b/src/graphics/ui/elements/Menu.cpp
@@ -1,6 +1,7 @@
 #include "Menu.hpp"
 
 #include <stdexcept>
+#include <utility>
 
 using namespace gui;
 
@@ -12,11 +13,11 @@ bool Menu::has(const std::string& name) {
            pageSuppliers.find(name) != pageSuppliers.end();
 }
 
-void Menu::addPage(std::string name, std::shared_ptr<UINode> panel) {
+void Menu::addPage(const std::string& name, const std::shared_ptr<UINode> &panel) {
     pages[name] = Page{name, panel};
 }
 
-void Menu::addSupplier(std::string name, supplier<std::shared_ptr<UINode>> pageSupplier) {
+void Menu::addSupplier(const std::string &name, const supplier<std::shared_ptr<UINode>> &pageSupplier) {
     pageSuppliers[name] = pageSupplier;
 }
 
@@ -38,7 +39,7 @@ std::shared_ptr<UINode> Menu::fetchPage(const std::string& name) {
     }
 }
 
-void Menu::setPage(std::string name, bool history) {
+void Menu::setPage(const std::string &name, bool history) {
     Page page {name, fetchPage(name)};
     if (page.panel == nullptr) {
         throw std::runtime_error("no page found");
@@ -53,7 +54,7 @@ void Menu::setPage(Page page, bool history) {
             pageStack.push(current);
         }
     }
-    current = page;
+    current = std::move(page);
     Container::add(current.panel);
     setSize(current.panel->getSize());
 }
@@ -73,7 +74,7 @@ void Menu::back() {
 }
 
 void Menu::setPageLoader(page_loader_func loader) {
-    pagesLoader = loader;
+    pagesLoader = std::move(loader);
 }
 
 Page& Menu::getCurrent() {

--- a/src/graphics/ui/elements/Menu.hpp
+++ b/src/graphics/ui/elements/Menu.hpp
@@ -30,15 +30,15 @@ namespace gui {
         /// @brief Set current page to specified one.
         /// @param name page or page supplier name
         /// @param history previous page will not be saved in history if false
-        void setPage(std::string name, bool history=true);
+        void setPage(const std::string &name, bool history=true);
         void setPage(Page page, bool history=true);
-        void addPage(std::string name, std::shared_ptr<UINode> panel);
+        void addPage(const std::string& name, const std::shared_ptr<UINode> &panel);
         std::shared_ptr<UINode> fetchPage(const std::string& name);
 
         /// @brief Add page supplier used if page is not found
         /// @param name page name
         /// @param pageSupplier page supplier function
-        void addSupplier(std::string name, supplier<std::shared_ptr<UINode>> pageSupplier);
+        void addSupplier(const std::string &name, const supplier<std::shared_ptr<UINode>> &pageSupplier);
 
         /// @brief Page loader is called if accessed page is not found 
         void setPageLoader(page_loader_func loader);

--- a/src/graphics/ui/elements/Panel.cpp
+++ b/src/graphics/ui/elements/Panel.cpp
@@ -46,7 +46,7 @@ void Panel::fullRefresh() {
     Container::fullRefresh();
 }
 
-void Panel::add(std::shared_ptr<UINode> node) {
+void Panel::add(const std::shared_ptr<UINode> &node) {
     node->setResizing(true);
     Container::add(node);
     fullRefresh();

--- a/src/graphics/ui/elements/Panel.hpp
+++ b/src/graphics/ui/elements/Panel.hpp
@@ -24,7 +24,7 @@ namespace gui {
         virtual void setOrientation(Orientation orientation);
         Orientation getOrientation() const;
 
-        virtual void add(std::shared_ptr<UINode> node) override;
+        virtual void add(const std::shared_ptr<UINode> &node) override;
 
         virtual void refresh() override;
         virtual void fullRefresh() override;

--- a/src/graphics/ui/elements/TextBox.cpp
+++ b/src/graphics/ui/elements/TextBox.cpp
@@ -1,5 +1,7 @@
 #include "TextBox.hpp"
 
+#include <utility>
+
 #include "Label.hpp"
 #include "../../core/DrawContext.hpp"
 #include "../../core/Batch2D.hpp"
@@ -14,7 +16,7 @@ using namespace gui;
 TextBox::TextBox(std::wstring placeholder, glm::vec4 padding) 
   : Panel(glm::vec2(200,32), padding, 0), 
     input(L""),
-    placeholder(placeholder)
+    placeholder(std::move(placeholder))
 {
     setOnUpPressed(nullptr);
     setOnDownPressed(nullptr);
@@ -556,7 +558,7 @@ std::shared_ptr<UINode> TextBox::getAt(glm::vec2 pos, std::shared_ptr<UINode> se
     return UINode::getAt(pos, self);
 }
 
-void TextBox::setOnUpPressed(runnable callback) {
+void TextBox::setOnUpPressed(const runnable &callback) {
     if (callback == nullptr) {
         onUpPressed = [this]() {
             bool shiftPressed = Events::pressed(keycode::LEFT_SHIFT);
@@ -568,7 +570,7 @@ void TextBox::setOnUpPressed(runnable callback) {
     }
 }
 
-void TextBox::setOnDownPressed(runnable callback) {
+void TextBox::setOnDownPressed(const runnable &callback) {
     if (callback == nullptr) {
         onDownPressed = [this]() {
             bool shiftPressed = Events::pressed(keycode::LEFT_SHIFT);
@@ -581,15 +583,15 @@ void TextBox::setOnDownPressed(runnable callback) {
 }
 
 void TextBox::setTextSupplier(wstringsupplier supplier) {
-    this->supplier = supplier;
+    this->supplier = std::move(supplier);
 }
 
 void TextBox::setTextConsumer(wstringconsumer consumer) {
-    this->consumer = consumer;
+    this->consumer = std::move(consumer);
 }
 
 void TextBox::setTextValidator(wstringchecker validator) {
-    this->validator = validator;
+    this->validator = std::move(validator);
 }
 
 void TextBox::setFocusedColor(glm::vec4 color) {
@@ -614,7 +616,7 @@ std::wstring TextBox::getText() const {
     return input;
 }
 
-void TextBox::setText(const std::wstring value) {
+void TextBox::setText(const std::wstring& value) {
     this->input = value;
     input.erase(std::remove(input.begin(), input.end(), '\r'), input.end());
 }

--- a/src/graphics/ui/elements/TextBox.hpp
+++ b/src/graphics/ui/elements/TextBox.hpp
@@ -98,7 +98,7 @@ namespace gui {
         virtual std::wstring getText() const;
 
         /// @brief Set TextBox content text
-        virtual void setText(std::wstring value);
+        virtual void setText(const std::wstring &value);
 
         /// @brief Get text placeholder
         virtual std::wstring getPlaceholder() const;
@@ -169,8 +169,8 @@ namespace gui {
         virtual void typed(unsigned int codepoint) override; 
         virtual void keyPressed(keycode key) override;
         virtual std::shared_ptr<UINode> getAt(glm::vec2 pos, std::shared_ptr<UINode> self) override;
-        virtual void setOnUpPressed(runnable callback);
-        virtual void setOnDownPressed(runnable callback);
+        virtual void setOnUpPressed(const runnable &callback);
+        virtual void setOnDownPressed(const runnable &callback);
     };
 }
 

--- a/src/graphics/ui/elements/TrackBar.cpp
+++ b/src/graphics/ui/elements/TrackBar.cpp
@@ -1,5 +1,7 @@
 #include "TrackBar.hpp"
 
+#include <utility>
+
 #include "../../core/DrawContext.hpp"
 #include "../../core/Batch2D.hpp"
 #include "../../../assets/Assets.hpp"
@@ -41,11 +43,11 @@ void TrackBar::draw(const DrawContext* pctx, Assets*) {
 }
 
 void TrackBar::setSupplier(doublesupplier supplier) {
-    this->supplier = supplier;
+    this->supplier = std::move(supplier);
 }
 
 void TrackBar::setConsumer(doubleconsumer consumer) {
-    this->consumer = consumer;
+    this->consumer = std::move(consumer);
 }
 
 void TrackBar::mouseMove(GUI*, int x, int) {

--- a/src/graphics/ui/elements/UINode.cpp
+++ b/src/graphics/ui/elements/UINode.cpp
@@ -1,5 +1,7 @@
 #include "UINode.hpp"
 
+#include <utility>
+
 #include "Container.hpp"
 #include "../../core/Batch2D.hpp"
 
@@ -62,12 +64,12 @@ UINode* UINode::getParent() const {
     return parent;
 }
 
-UINode* UINode::listenAction(onaction action) {
+UINode* UINode::listenAction(const onaction& action) {
     actions.listen(action);
     return this;
 }
 
-UINode* UINode::listenDoubleClick(onaction action) {
+UINode* UINode::listenDoubleClick(const onaction& action) {
     doubleClickCallbacks.listen(action);
     return this;
 }
@@ -113,7 +115,7 @@ std::shared_ptr<UINode> UINode::getAt(glm::vec2 point, std::shared_ptr<UINode> s
     if (!isInteractive() || !enabled) {
         return nullptr;
     }
-    return isInside(point) ? self : nullptr;
+    return isInside(point) ? std::move(self) : nullptr;
 }
 
 bool UINode::isInteractive() const {
@@ -241,8 +243,8 @@ int UINode::getZIndex() const {
 }
 
 void UINode::moveInto(
-    std::shared_ptr<UINode> node,
-    std::shared_ptr<Container> dest
+    const std::shared_ptr<UINode>& node,
+    const std::shared_ptr<Container>& dest
 ) {
     auto parent = node->getParent();
     if (auto container = dynamic_cast<Container*>(parent)) {
@@ -259,7 +261,7 @@ vec2supplier UINode::getPositionFunc() const {
 }
 
 void UINode::setPositionFunc(vec2supplier func) {
-    positionfunc = func;
+    positionfunc = std::move(func);
 }
 
 vec2supplier UINode::getSizeFunc() const {
@@ -267,7 +269,7 @@ vec2supplier UINode::getSizeFunc() const {
 }
 
 void UINode::setSizeFunc(vec2supplier func) {
-    sizefunc = func;
+    sizefunc = std::move(func);
 }
 
 void UINode::setId(const std::string& id) {
@@ -345,7 +347,7 @@ bool UINode::isSubnodeOf(const UINode* node) {
 }
 
 void UINode::getIndices(
-    const std::shared_ptr<UINode> node,
+    const std::shared_ptr<UINode>& node,
     std::unordered_map<std::string, std::shared_ptr<UINode>>& map
 ) {
     const std::string& id = node->getId();
@@ -354,20 +356,20 @@ void UINode::getIndices(
     }
     auto container = std::dynamic_pointer_cast<gui::Container>(node);
     if (container) {
-        for (auto subnode : container->getNodes()) {
+        for (const auto& subnode : container->getNodes()) {
             getIndices(subnode, map);
         }
     }
 }
 std::shared_ptr<UINode> UINode::find(
-    const std::shared_ptr<UINode> node,
+    const std::shared_ptr<UINode>& node,
     const std::string& id
 ) {
     if (node->getId() == id) {
         return node;
     }
     if (auto container = std::dynamic_pointer_cast<Container>(node)) {
-        for (auto subnode : container->getNodes()) {
+        for (const auto& subnode : container->getNodes()) {
             if (auto found = UINode::find(subnode, id)) {
                 return found;
             }

--- a/src/graphics/ui/elements/UINode.hpp
+++ b/src/graphics/ui/elements/UINode.hpp
@@ -25,7 +25,7 @@ namespace gui {
     class ActionsSet {
         std::unique_ptr<std::vector<onaction>> callbacks;
     public:
-        void listen(onaction callback) {
+        void listen(const onaction& callback) {
             if (callbacks == nullptr) {
                 callbacks = std::make_unique<std::vector<onaction>>();
             }
@@ -162,8 +162,8 @@ namespace gui {
         /// @brief Get element z-index
         int getZIndex() const;
 
-        virtual UINode* listenAction(onaction action);
-        virtual UINode* listenDoubleClick(onaction action);
+        virtual UINode* listenAction(const onaction &action);
+        virtual UINode* listenDoubleClick(const onaction &action);
 
         virtual void onFocus(GUI*) {focused = true;}
         virtual void doubleClick(GUI*, int x, int y);
@@ -227,8 +227,8 @@ namespace gui {
             }
         };
         static void moveInto(
-            std::shared_ptr<UINode> node,
-            std::shared_ptr<Container> dest
+            const std::shared_ptr<UINode>& node,
+            const std::shared_ptr<Container>& dest
         );
 
         virtual vec2supplier getPositionFunc() const;
@@ -249,12 +249,12 @@ namespace gui {
 
         /// @brief collect all nodes having id
         static void getIndices(
-            const std::shared_ptr<UINode> node,
+            const std::shared_ptr<UINode>& node,
             std::unordered_map<std::string, std::shared_ptr<UINode>>& map
         );
 
         static std::shared_ptr<UINode> find(
-            const std::shared_ptr<UINode> node,
+            const std::shared_ptr<UINode>& node,
             const std::string& id
         );
     };

--- a/src/graphics/ui/gui_util.cpp
+++ b/src/graphics/ui/gui_util.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<gui::UINode> guiutil::create(const std::string& source, scripten
     return reader.readXML("<string>", source);
 }
 
-void guiutil::alert(GUI* gui, const std::wstring& text, runnable on_hidden) {
+void guiutil::alert(GUI* gui, const std::wstring& text, const runnable& on_hidden) {
     auto menu = gui->getMenu();
     auto panel = std::make_shared<Panel>(glm::vec2(500, 300), glm::vec4(8.0f), 8.0f);
     panel->setColor(glm::vec4(0.0f, 0.0f, 0.0f, 0.5f));
@@ -48,7 +48,7 @@ void guiutil::alert(GUI* gui, const std::wstring& text, runnable on_hidden) {
 void guiutil::confirm(
         GUI* gui, 
         const std::wstring& text, 
-        runnable on_confirm,
+        const runnable& on_confirm,
         std::wstring yestext, 
         std::wstring notext) {
     if (yestext.empty()) yestext = langs::get(L"Yes");

--- a/src/graphics/ui/gui_util.hpp
+++ b/src/graphics/ui/gui_util.hpp
@@ -16,13 +16,13 @@ namespace guiutil {
     void alert(
         gui::GUI* gui, 
         const std::wstring& text, 
-        runnable on_hidden=nullptr
+        const runnable& on_hidden=nullptr
     );
 
     void confirm(
         gui::GUI* gui, 
         const std::wstring& text, 
-        runnable on_confirm=nullptr,
+        const runnable& on_confirm=nullptr,
         std::wstring yestext=L"", 
         std::wstring notext=L"");
 }

--- a/src/graphics/ui/gui_xml.hpp
+++ b/src/graphics/ui/gui_xml.hpp
@@ -27,17 +27,17 @@ namespace gui {
         bool hasReader(const std::string& tag) const;
         void addIgnore(const std::string& tag);
         
-        std::shared_ptr<UINode> readUINode(xml::xmlelement element);
+        std::shared_ptr<UINode> readUINode(const xml::xmlelement& element);
         
         void readUINode(
             UiXmlReader& reader, 
-            xml::xmlelement element, 
+            const xml::xmlelement& element,
             UINode& node
         );
 
         void readUINode(
             UiXmlReader& reader, 
-            xml::xmlelement element, 
+            const xml::xmlelement& element,
             Container& container
         );
 
@@ -48,7 +48,7 @@ namespace gui {
 
         std::shared_ptr<UINode> readXML(
             const std::string& filename,
-            xml::xmlelement root
+            const xml::xmlelement& root
         );
 
         const std::string& getContext() const;

--- a/src/items/Inventories.cpp
+++ b/src/items/Inventories.cpp
@@ -31,7 +31,7 @@ std::shared_ptr<Inventory> Inventories::createVirtual(size_t size) {
     });
 }
 
-void Inventories::store(std::shared_ptr<Inventory> inv) {
+void Inventories::store(const std::shared_ptr<Inventory>& inv) {
     map[inv->getId()] = inv;
 }
 

--- a/src/items/Inventories.hpp
+++ b/src/items/Inventories.hpp
@@ -28,7 +28,7 @@ public:
     std::shared_ptr<Inventory> createVirtual(size_t size);
 
     /* Store inventory */
-    void store(std::shared_ptr<Inventory> inv);
+    void store(const std::shared_ptr<Inventory>& inv);
 
     /* Remove inventory from map */
     void remove(int64_t id);

--- a/src/items/ItemDef.cpp
+++ b/src/items/ItemDef.cpp
@@ -1,6 +1,6 @@
 #include "ItemDef.hpp"
 #include "../util/stringutil.hpp"
 
-ItemDef::ItemDef(std::string name) : name(name) {
+ItemDef::ItemDef(const std::string& name) : name(name) {
     caption = util::id_to_caption(name);
 }

--- a/src/items/ItemDef.hpp
+++ b/src/items/ItemDef.hpp
@@ -44,7 +44,7 @@ public:
         bool emissive = false;
     } rt;
 
-    ItemDef(std::string name);
+    ItemDef(const std::string& name);
     ItemDef(const ItemDef&) = delete;
 };
 

--- a/src/logic/ChunksController.cpp
+++ b/src/logic/ChunksController.cpp
@@ -90,7 +90,7 @@ bool ChunksController::loadVisible(){
     return true;
 }
 
-bool ChunksController::buildLights(std::shared_ptr<Chunk> chunk) {
+bool ChunksController::buildLights(const std::shared_ptr<Chunk>& chunk) {
     int surrounding = 0;
     for (int oz = -1; oz <= 1; oz++){
         for (int ox = -1; ox <= 1; ox++){

--- a/src/logic/ChunksController.hpp
+++ b/src/logic/ChunksController.hpp
@@ -21,7 +21,7 @@ private:
 
     /// @brief Process one chunk: load it or calculate lights for it
     bool loadVisible();
-    bool buildLights(std::shared_ptr<Chunk> chunk);
+    bool buildLights(const std::shared_ptr<Chunk>& chunk);
     void createChunk(int x, int y);
 public:
     ChunksController(Level* level, uint padding);

--- a/src/logic/CommandsInterpreter.cpp
+++ b/src/logic/CommandsInterpreter.cpp
@@ -4,6 +4,7 @@
 #include "../util/stringutil.hpp"
 
 #include <iostream>
+#include <utility>
 
 using namespace cmd;
 
@@ -156,7 +157,7 @@ public:
         }
         return Command(
             name, std::move(args), std::move(kwargs),
-             std::string(description), executor
+             std::string(description), std::move(executor)
         );
     }
 
@@ -256,7 +257,7 @@ public:
     dynamic::Value applyRelative(
         Argument* arg, 
         dynamic::Value value,
-        dynamic::Value origin
+        const dynamic::Value& origin
     ) {
         if (origin.index() == 0) {
             return value;
@@ -380,7 +381,7 @@ public:
 };
 
 Command Command::create(std::string_view scheme, std::string_view description, executor_func executor) {
-    return CommandParser("<string>", scheme).parseScheme(executor, description);
+    return CommandParser("<string>", scheme).parseScheme(std::move(executor), description);
 }
 
 void CommandsRepository::add(
@@ -388,7 +389,7 @@ void CommandsRepository::add(
     std::string_view description, 
     executor_func executor
 ) {
-    Command command = Command::create(scheme, description, executor);
+    Command command = Command::create(scheme, description, std::move(executor));
     commands[command.getName()] = command;
 }
 

--- a/src/logic/EngineController.cpp
+++ b/src/logic/EngineController.cpp
@@ -27,7 +27,7 @@ static debug::Logger logger("engine-control");
 EngineController::EngineController(Engine* engine) : engine(engine) {
 }
 
-void EngineController::deleteWorld(std::string name) {
+void EngineController::deleteWorld(const std::string& name) {
     fs::path folder = engine->getPaths()->getWorldFolder(name);
     guiutil::confirm(engine->getGUI(), langs::get(L"delete-confirm", L"world")+
     L" ("+util::str2wstr_utf8(folder.u8string())+L")", [=]() {
@@ -38,10 +38,10 @@ void EngineController::deleteWorld(std::string name) {
 
 std::shared_ptr<Task> create_converter(
     Engine* engine,
-    fs::path folder, 
+    const fs::path& folder,
     const Content* content, 
-    std::shared_ptr<ContentLUT> lut, 
-    runnable postRunnable)
+    const std::shared_ptr<ContentLUT>& lut,
+    const runnable& postRunnable)
 {
     return WorldConverter::startTask(folder, content, lut, [=](){
         auto menu = engine->getGUI()->getMenu();
@@ -56,9 +56,9 @@ std::shared_ptr<Task> create_converter(
 void show_convert_request(
     Engine* engine, 
     const Content* content, 
-    std::shared_ptr<ContentLUT> lut,
-    fs::path folder,
-    runnable postRunnable
+    const std::shared_ptr<ContentLUT>& lut,
+    const fs::path& folder,
+    const runnable& postRunnable
 ) {
     guiutil::confirm(engine->getGUI(), langs::get(L"world.convert-request"), [=]() {
         auto converter = create_converter(engine, folder, content, lut, postRunnable);
@@ -68,7 +68,7 @@ void show_convert_request(
 
 static void show_content_missing(
     Engine* engine,
-    std::shared_ptr<ContentLUT> lut
+    const std::shared_ptr<ContentLUT>& lut
 ) {
     using namespace dynamic;
     auto root = create_map();
@@ -82,7 +82,7 @@ static void show_content_missing(
     menus::show(engine, "reports/missing_content", {root});
 }
 
-static bool loadWorldContent(Engine* engine, fs::path folder) {
+static bool loadWorldContent(Engine* engine, const fs::path& folder) {
     try {
         engine->loadWorldContent(folder);
         return true;
@@ -104,7 +104,7 @@ static bool loadWorldContent(Engine* engine, fs::path folder) {
     }
 }
 
-static void loadWorld(Engine* engine, fs::path folder) {
+static void loadWorld(Engine* engine, const fs::path& folder) {
     try {
         auto content = engine->getContent();
         auto& packs = engine->getContentPacks();
@@ -121,7 +121,7 @@ static void loadWorld(Engine* engine, fs::path folder) {
     }
 }
 
-void EngineController::openWorld(std::string name, bool confirmConvert) {
+void EngineController::openWorld(const std::string& name, bool confirmConvert) {
     auto paths = engine->getPaths();
     auto folder = paths->getWorldsFolder()/fs::u8path(name);
     if (!loadWorldContent(engine, folder)) {
@@ -215,8 +215,8 @@ void EngineController::reopenWorld(World* world) {
 
 void EngineController::reconfigPacks(
     LevelController* controller,
-    std::vector<std::string> packsToAdd,
-    std::vector<std::string> packsToRemove
+    const std::vector<std::string>& packsToAdd,
+    const std::vector<std::string>& packsToRemove
 ) {
     auto content = engine->getContent();
     bool hasIndices = false;

--- a/src/logic/EngineController.hpp
+++ b/src/logic/EngineController.hpp
@@ -16,16 +16,16 @@ public:
     /// @brief Load world, convert if required and set to LevelScreen.
     /// @param name world name
     /// @param confirmConvert automatically confirm convert if requested
-    void openWorld(std::string name, bool confirmConvert);
+    void openWorld(const std::string& name, bool confirmConvert);
 
     /// @brief Show world removal confirmation dialog
     /// @param name world name
-    void deleteWorld(std::string name);
+    void deleteWorld(const std::string& name);
 
     void reconfigPacks(
         LevelController* controller,
-        std::vector<std::string> packsToAdd,
-        std::vector<std::string> packsToRemove
+        const std::vector<std::string>& packsToAdd,
+        const std::vector<std::string>& packsToRemove
     );
 
     void createWorld(

--- a/src/logic/LevelController.cpp
+++ b/src/logic/LevelController.cpp
@@ -39,7 +39,7 @@ void LevelController::update(float delta, bool input, bool pause) {
     
     if (!pause) {
         // update all objects that needed
-        for (auto obj : level->objects) {
+        for (const auto& obj : level->objects) {
             if (obj && obj->shouldUpdate) {
                 obj->update(delta);
             }

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -35,7 +35,7 @@ const float RUN_ZOOM = 1.1f;
 const float C_ZOOM = 0.1f;
 const float CROUCH_SHIFT_Y = -0.2f;
 
-CameraControl::CameraControl(std::shared_ptr<Player> player, const CameraSettings& settings) 
+CameraControl::CameraControl(const std::shared_ptr<Player>& player, const CameraSettings& settings)
   : player(player), 
     camera(player->camera),
     settings(settings),
@@ -186,7 +186,7 @@ void PlayerController::onBlockInteraction(
     const Block* def,
     BlockInteraction type
 ) {
-    for (auto callback : blockInteractionCallbacks) {
+    for (const auto& callback : blockInteractionCallbacks) {
         callback(player.get(), pos, def, type);
     }
 }
@@ -456,6 +456,6 @@ Player* PlayerController::getPlayer() {
     return player.get();
 }
 
-void PlayerController::listenBlockInteraction(on_block_interaction callback) {
+void PlayerController::listenBlockInteraction(const on_block_interaction& callback) {
     blockInteractionCallbacks.push_back(callback);
 }

--- a/src/logic/PlayerController.hpp
+++ b/src/logic/PlayerController.hpp
@@ -37,7 +37,7 @@ class CameraControl {
     /// @brief Switch active player camera
     void switchCamera();
 public:
-    CameraControl(std::shared_ptr<Player> player, const CameraSettings& settings);
+    CameraControl(const std::shared_ptr<Player>& player, const CameraSettings& settings);
     void updateMouse(PlayerInput& input);
     void update(const PlayerInput& input, float delta, Chunks* chunks);
     void refresh();
@@ -91,7 +91,7 @@ public:
 
     Player* getPlayer();
 
-    void listenBlockInteraction(on_block_interaction callback);
+    void listenBlockInteraction(const on_block_interaction& callback);
 };
 
 #endif /* PLAYER_CONTROL_HPP_ */

--- a/src/logic/scripting/lua/libcore.cpp
+++ b/src/logic/scripting/lua/libcore.cpp
@@ -103,7 +103,7 @@ static int l_reconfig_packs(lua_State* L) {
 static int l_get_setting(lua_State* L) {
     auto name = lua_tostring(L, 1);
     const auto value = scripting::engine->getSettingsHandler().getValue(name);
-    scripting::state->pushvalue(std::move(value));
+    scripting::state->pushvalue(value);
     return 1;
 }
 

--- a/src/logic/scripting/lua/libgui.cpp
+++ b/src/logic/scripting/lua/libgui.cpp
@@ -494,7 +494,7 @@ static void p_set_inventory(UINode* node, int idx) {
         }
     }
 }
-static void p_set_focused(std::shared_ptr<UINode> node, int idx) {
+static void p_set_focused(const std::shared_ptr<UINode> &node, int idx) {
     if (state->toboolean(idx) && !node->isFocused()) {
         scripting::engine->getGUI()->setFocus(node);
     } else if (node->isFocused()){

--- a/src/logic/scripting/scripting.cpp
+++ b/src/logic/scripting/scripting.cpp
@@ -37,7 +37,7 @@ const ContentIndices* scripting::indices = nullptr;
 BlocksController* scripting::blocks = nullptr;
 LevelController* scripting::controller = nullptr;
 
-void load_script(fs::path name) {
+void load_script(const fs::path& name) {
     auto paths = scripting::engine->getPaths();
     fs::path file = paths->getResources()/fs::path("scripts")/name;
 
@@ -72,7 +72,7 @@ scriptenv scripting::create_pack_environment(const ContentPack& pack) {
     });
 }
 
-scriptenv scripting::create_doc_environment(scriptenv parent, const std::string& name) {
+scriptenv scripting::create_doc_environment(const scriptenv& parent, const std::string& name) {
     int id = state->createEnvironment(*parent);
     state->pushenv(id);
     state->pushvalue(-1);
@@ -279,7 +279,7 @@ bool scripting::register_event(int env, const std::string& name, const std::stri
     return false;
 }
 
-void scripting::load_block_script(scriptenv senv, std::string prefix, fs::path file, block_funcs_set& funcsset) {
+void scripting::load_block_script(const scriptenv& senv, const std::string& prefix, const fs::path& file, block_funcs_set& funcsset) {
     int env = *senv;
     std::string src = files::read_string(file);
     logger.info() << "script (block) " << file.u8string();
@@ -293,7 +293,7 @@ void scripting::load_block_script(scriptenv senv, std::string prefix, fs::path f
     funcsset.onblockstick = register_event(env, "on_blocks_tick", prefix+".blockstick");
 }
 
-void scripting::load_item_script(scriptenv senv, std::string prefix, fs::path file, item_funcs_set& funcsset) {
+void scripting::load_item_script(const scriptenv& senv, const std::string& prefix, const fs::path& file, item_funcs_set& funcsset) {
     int env = *senv;
     std::string src = files::read_string(file);
     logger.info() << "script (item) " << file.u8string();
@@ -305,7 +305,7 @@ void scripting::load_item_script(scriptenv senv, std::string prefix, fs::path fi
     funcsset.on_block_break_by = register_event(env, "on_block_break_by", prefix+".blockbreakby");
 }
 
-void scripting::load_world_script(scriptenv senv, std::string prefix, fs::path file) {
+void scripting::load_world_script(const scriptenv& senv, const std::string& prefix, const fs::path& file) {
     int env = *senv;
 
     std::string src = files::read_string(file);
@@ -321,7 +321,7 @@ void scripting::load_world_script(scriptenv senv, std::string prefix, fs::path f
     register_event(env, "on_world_quit", prefix+".worldquit");
 }
 
-void scripting::load_layout_script(scriptenv senv, std::string prefix, fs::path file, uidocscript& script) {
+void scripting::load_layout_script(const scriptenv& senv, const std::string& prefix, const fs::path& file, uidocscript& script) {
     int env = *senv;
 
     std::string src = files::read_string(file);

--- a/src/logic/scripting/scripting.hpp
+++ b/src/logic/scripting/scripting.hpp
@@ -45,7 +45,7 @@ namespace scripting {
 
     scriptenv get_root_environment();
     scriptenv create_pack_environment(const ContentPack& pack);
-    scriptenv create_doc_environment(scriptenv parent, const std::string& name);
+    scriptenv create_doc_environment(const scriptenv& parent, const std::string& name);
 
     void process_post_runnables();
 
@@ -88,27 +88,27 @@ namespace scripting {
     /// @param prefix pack id
     /// @param file item script file
     /// @param funcsset block callbacks set
-    void load_block_script(scriptenv env, std::string prefix, fs::path file, block_funcs_set& funcsset);
+    void load_block_script(const scriptenv& env, const std::string& prefix, const fs::path& file, block_funcs_set& funcsset);
 
     /// @brief Load script associated with an Item
     /// @param env environment
     /// @param prefix pack id
     /// @param file item script file
     /// @param funcsset item callbacks set
-    void load_item_script(scriptenv env, std::string prefix, fs::path file, item_funcs_set& funcsset);
+    void load_item_script(const scriptenv& env, const std::string& prefix, const fs::path& file, item_funcs_set& funcsset);
     
     /// @brief Load package-specific world script 
     /// @param env environment
     /// @param packid content-pack id
     /// @param file script file path
-    void load_world_script(scriptenv env, std::string packid, fs::path file);
+    void load_world_script(const scriptenv& env, const std::string& packid, const fs::path& file);
 
     /// @brief Load script associated with an UiDocument
     /// @param env environment
     /// @param prefix pack id
     /// @param file item script file
     /// @param script document script info
-    void load_layout_script(scriptenv env, std::string prefix, fs::path file, uidocscript& script);
+    void load_layout_script(const scriptenv& env, const std::string& prefix, const fs::path& file, uidocscript& script);
 
     /// @brief Finalize lua state. Using scripting after will lead to Lua panic
     void close();

--- a/src/logic/scripting/scripting_hud.cpp
+++ b/src/logic/scripting/scripting_hud.cpp
@@ -40,7 +40,7 @@ void scripting::on_frontend_close() {
     scripting::hud = nullptr;
 }
 
-void scripting::load_hud_script(scriptenv senv, std::string packid, fs::path file) {
+void scripting::load_hud_script(const scriptenv& senv, const std::string& packid, const fs::path& file) {
     int env = *senv;
     std::string src = files::read_string(file);
     logger.info() << "loading script " << file.u8string();

--- a/src/logic/scripting/scripting_hud.hpp
+++ b/src/logic/scripting/scripting_hud.hpp
@@ -17,12 +17,12 @@ namespace scripting {
     void on_frontend_close();
 
     /** 
-     * Load package-specific hud script 
+     * Load package-specific hud script
      * @param env environment id
      * @param packid content-pack id
      * @param file script file path
      */
-    void load_hud_script(scriptenv env, std::string packid, fs::path file);
+    void load_hud_script(const scriptenv &env, const std::string &packid, const fs::path &file);
 }
 
 #endif // LOGIC_SCRIPTING_SCRIPTING_HUD_HPP_

--- a/src/objects/Player.cpp
+++ b/src/objects/Player.cpp
@@ -10,6 +10,7 @@
 #include "../items/Inventory.hpp"
 
 #include <glm/glm.hpp>
+#include <utility>
 
 const float CROUCH_SPEED_MUL = 0.35f;
 const float RUN_SPEED_MUL = 1.5f;
@@ -22,7 +23,7 @@ const float JUMP_FORCE = 8.0f;
 Player::Player(glm::vec3 position, float speed, std::shared_ptr<Inventory> inv) :
     speed(speed),
     chosenSlot(0),
-    inventory(inv),
+    inventory(std::move(inv)),
     camera(std::make_shared<Camera>(position, glm::radians(90.0f))),
     spCamera(std::make_shared<Camera>(position, glm::radians(90.0f))),
     tpCamera(std::make_shared<Camera>(position, glm::radians(90.0f))),

--- a/src/util/RunnablesList.hpp
+++ b/src/util/RunnablesList.hpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <utility>
 
 namespace util {
     class RunnablesList {
@@ -14,7 +15,7 @@ namespace util {
     public:
         observer_handler add(runnable callback) {
             int id = nextid++;
-            runnables[id] = callback;
+            runnables[id] = std::move(callback);
             return observer_handler(new int(id), [this](int* id) {
                 runnables.erase(*id);
                 delete id;

--- a/src/util/ThreadPool.hpp
+++ b/src/util/ThreadPool.hpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <functional>
 #include <condition_variable>
+#include <utility>
 
 namespace util {
     
@@ -106,7 +107,7 @@ public:
         std::string name,
         supplier<std::shared_ptr<Worker<T, R>>> workersSupplier, 
         consumer<R&> resultConsumer
-    ) : logger(name), resultConsumer(resultConsumer) {
+    ) : logger(std::move(name)), resultConsumer(resultConsumer) {
         const uint num_threads = std::thread::hardware_concurrency();
         for (uint i = 0; i < num_threads; i++) {
             threads.emplace_back(&ThreadPool<T,R>::threadLoop, this, i, workersSupplier());

--- a/src/util/stringutil.cpp
+++ b/src/util/stringutil.cpp
@@ -128,7 +128,7 @@ extern uint32_t util::decode_utf8(uint& size, const char* chr) {
     return code;
 }
 
-std::string util::wstr2str_utf8(const std::wstring ws) {
+std::string util::wstr2str_utf8(const std::wstring& ws) {
     std::vector<char> chars;
     char buffer[4];
     for (wchar_t wc : ws) {
@@ -140,7 +140,7 @@ std::string util::wstr2str_utf8(const std::wstring ws) {
     return std::string(chars.data(), chars.size());
 }
 
-std::wstring util::str2wstr_utf8(const std::string s) {
+std::wstring util::str2wstr_utf8(const std::string& s) {
     std::vector<wchar_t> chars;
     size_t pos = 0;
     uint size = 0;
@@ -167,7 +167,7 @@ bool util::is_integer(const std::wstring& text) {
     return true;
 }
 
-bool util::is_valid_filename(std::wstring name) {
+bool util::is_valid_filename(const std::wstring& name) {
     for (wchar_t c : name) {
         if (c < 31 || c == '/' || c == '\\' || c == '<' || c == '>' ||
             c == ':' || c == '"' || c == '|' || c == '?' || c == '*'){

--- a/src/util/stringutil.hpp
+++ b/src/util/stringutil.hpp
@@ -18,11 +18,11 @@ namespace util {
 
     uint encode_utf8(uint32_t c, ubyte* bytes);
     uint32_t decode_utf8(uint& size, const char* bytes);
-    std::string wstr2str_utf8(const std::wstring ws);
-    std::wstring str2wstr_utf8(const std::string s);
+    std::string wstr2str_utf8(const std::wstring &ws);
+    std::wstring str2wstr_utf8(const std::string &s);
     bool is_integer(const std::string& text);
     bool is_integer(const std::wstring& text);
-    bool is_valid_filename(std::wstring name);
+    bool is_valid_filename(const std::wstring &name);
 
     void ltrim(std::string &s);
     void rtrim(std::string &s);

--- a/src/voxels/Block.cpp
+++ b/src/voxels/Block.cpp
@@ -1,5 +1,7 @@
 #include "Block.hpp"
 
+#include <utility>
+
 #include "../core_defs.hpp"
 #include "../util/stringutil.hpp"
 
@@ -38,7 +40,7 @@ const BlockRotProfile BlockRotProfile::PANE {"pane", {
 		{ { 0, 0, 1 }, { 0, 1, 0 }, {-1, 0, 0 }}, // West
 }};
 
-Block::Block(std::string name) 
+Block::Block(const std::string& name)
 	: name(name), 
       caption(util::id_to_caption(name)),
 	  textureFaces {TEXTURE_NOTFOUND,TEXTURE_NOTFOUND,TEXTURE_NOTFOUND,
@@ -46,7 +48,7 @@ Block::Block(std::string name)
       rotations(BlockRotProfile::PIPE)
 {}
 
-Block::Block(std::string name, std::string texture) : name(name),
+Block::Block(std::string name, const std::string& texture) : name(std::move(name)),
 		textureFaces{texture,texture,texture,texture,texture,texture},
         rotations(BlockRotProfile::PIPE)
 {}

--- a/src/voxels/Block.hpp
+++ b/src/voxels/Block.hpp
@@ -186,8 +186,8 @@ public:
         itemid_t pickingItem = 0;
     } rt;
 
-    Block(std::string name);
-    Block(std::string name, std::string texture);
+    Block(const std::string& name);
+    Block(std::string name, const std::string& texture);
     Block(const Block&) = delete;
 };
 

--- a/src/voxels/Chunk.cpp
+++ b/src/voxels/Chunk.cpp
@@ -1,5 +1,7 @@
 #include "Chunk.hpp"
 
+#include <utility>
+
 #include "voxel.hpp"
 
 #include "../items/Inventory.hpp"
@@ -41,7 +43,7 @@ void Chunk::updateHeights() {
 
 void Chunk::addBlockInventory(std::shared_ptr<Inventory> inventory, 
                               uint x, uint y, uint z) {
-    inventories[vox_index(x, y, z)] = inventory;
+    inventories[vox_index(x, y, z)] = std::move(inventory);
     flags.unsaved = true;
 }
 
@@ -52,7 +54,7 @@ void Chunk::removeBlockInventory(uint x, uint y, uint z) {
 }
 
 void Chunk::setBlockInventories(chunk_inventories_map map) {
-    inventories = map;
+    inventories = std::move(map);
 }
 
 std::shared_ptr<Inventory> Chunk::getBlockInventory(uint x, uint y, uint z) const {

--- a/src/voxels/Chunks.cpp
+++ b/src/voxels/Chunks.cpp
@@ -480,7 +480,7 @@ void Chunks::_setOffset(int32_t x, int32_t z) {
     oz = z;
 }
 
-bool Chunks::putChunk(std::shared_ptr<Chunk> chunk) {
+bool Chunks::putChunk(const std::shared_ptr<Chunk>& chunk) {
     int x = chunk->x;
     int z = chunk->z;
     x -= ox;

--- a/src/voxels/Chunks.hpp
+++ b/src/voxels/Chunks.hpp
@@ -36,7 +36,7 @@ public:
            WorldFiles* worldFiles, LevelEvents* events, const Content* content);
     ~Chunks() = default;
 
-    bool putChunk(std::shared_ptr<Chunk> chunk);
+    bool putChunk(const std::shared_ptr<Chunk>& chunk);
 
     Chunk* getChunk(int32_t x, int32_t z);
     Chunk* getChunkByVoxel(int32_t x, int32_t y, int32_t z);

--- a/src/voxels/ChunksStorage.cpp
+++ b/src/voxels/ChunksStorage.cpp
@@ -18,7 +18,7 @@ static debug::Logger logger("chunks-storage");
 ChunksStorage::ChunksStorage(Level* level) : level(level) {
 }
 
-void ChunksStorage::store(std::shared_ptr<Chunk> chunk) {
+void ChunksStorage::store(const std::shared_ptr<Chunk>& chunk) {
 	chunksMap[glm::ivec2(chunk->x, chunk->z)] = chunk;
 }
 

--- a/src/voxels/ChunksStorage.hpp
+++ b/src/voxels/ChunksStorage.hpp
@@ -21,7 +21,7 @@ public:
     ~ChunksStorage() = default;
 
     std::shared_ptr<Chunk> get(int x, int z) const;
-    void store(std::shared_ptr<Chunk> chunk);
+    void store(const std::shared_ptr<Chunk>& chunk);
     void remove(int x, int y);
     void getVoxels(VoxelsVolume* volume, bool backlight=false) const;
     std::shared_ptr<Chunk> create(int x, int z);

--- a/src/world/LevelEvents.cpp
+++ b/src/world/LevelEvents.cpp
@@ -3,14 +3,14 @@
 
 using std::vector;
 
-void LevelEvents::listen(lvl_event_type type, chunk_event_func func) {
+void LevelEvents::listen(lvl_event_type type, const chunk_event_func& func) {
 	auto& callbacks = chunk_callbacks[type];
 	callbacks.push_back(func);
 }
 
 void LevelEvents::trigger(lvl_event_type type, Chunk* chunk) {
 	const auto& callbacks = chunk_callbacks[type];
-	for (chunk_event_func func : callbacks) {
+	for (const chunk_event_func& func : callbacks) {
 		func(type, chunk);
 	}
 }

--- a/src/world/LevelEvents.hpp
+++ b/src/world/LevelEvents.hpp
@@ -16,7 +16,7 @@ using chunk_event_func = std::function<void(lvl_event_type, Chunk*)>;
 class LevelEvents {
     std::unordered_map<lvl_event_type, std::vector<chunk_event_func>> chunk_callbacks;
 public:
-    void listen(lvl_event_type type, chunk_event_func func);
+    void listen(lvl_event_type type, const chunk_event_func& func);
     void trigger(lvl_event_type type, Chunk* chunk);
 };
 

--- a/src/world/World.cpp
+++ b/src/world/World.cpp
@@ -16,23 +16,24 @@
 
 #include <memory>
 #include <glm/glm.hpp>
+#include <utility>
 
 static debug::Logger logger("world");
 
-world_load_error::world_load_error(std::string message) 
+world_load_error::world_load_error(const std::string& message)
     : std::runtime_error(message) {
 }
 
 World::World(
     std::string name, 
     std::string generator,
-    fs::path directory, 
+    const fs::path& directory,
     uint64_t seed, 
     EngineSettings& settings,
     const Content* content,
-    const std::vector<ContentPack> packs
-) : name(name),
-    generator(generator),
+    const std::vector<ContentPack>& packs
+) : name(std::move(name)),
+    generator(std::move(generator)),
     seed(seed),
     settings(settings), 
     content(content),
@@ -70,7 +71,7 @@ void World::write(Level* level) {
     auto playerFile = dynamic::Map();
 
     auto& players = playerFile.putList("players");
-    for (auto object : level->objects) {
+    for (const auto& object : level->objects) {
         if (auto player = std::dynamic_pointer_cast<Player>(object)) {
             players.put(player->serialize());
         }
@@ -79,9 +80,9 @@ void World::write(Level* level) {
 }
 
 std::unique_ptr<Level> World::create(
-    std::string name, 
-    std::string generator,
-    fs::path directory, 
+    const std::string& name,
+    const std::string& generator,
+    const fs::path& directory,
     uint64_t seed,
     EngineSettings& settings, 
     const Content* content,
@@ -94,7 +95,7 @@ std::unique_ptr<Level> World::create(
 }
 
 std::unique_ptr<Level> World::load(
-    fs::path directory,
+    const fs::path& directory,
     EngineSettings& settings,
     const Content* content,
     const std::vector<ContentPack>& packs

--- a/src/world/World.hpp
+++ b/src/world/World.hpp
@@ -22,7 +22,7 @@ namespace fs = std::filesystem;
 
 class world_load_error : public std::runtime_error {
 public:
-    world_load_error(std::string message);
+    world_load_error(const std::string &message);
 };
 
 /// @brief holds all world data except the level (chunks and objects)
@@ -55,11 +55,11 @@ public:
     World(
         std::string name, 
         std::string generator,
-        fs::path directory, 
+        const fs::path& directory,
         uint64_t seed, 
         EngineSettings& settings,
         const Content* content,
-        std::vector<ContentPack> packs
+        const std::vector<ContentPack>& packs
     );
 
     ~World();
@@ -90,9 +90,9 @@ public:
     /// @param packs vector of all world content-packs
     /// @return Level instance containing World instance
     static std::unique_ptr<Level> create(
-        std::string name, 
-        std::string generator,
-        fs::path directory, 
+        const std::string& name,
+        const std::string& generator,
+        const fs::path& directory,
         uint64_t seed, 
         EngineSettings& settings, 
         const Content* content,
@@ -108,7 +108,7 @@ public:
     /// @return Level instance containing World instance
     /// @throws world_load_error on world.json load error
     static std::unique_ptr<Level> load(
-        fs::path directory,
+        const fs::path& directory,
         EngineSettings& settings,
         const Content* content,
         const std::vector<ContentPack>& packs

--- a/src/world/WorldGenerators.cpp
+++ b/src/world/WorldGenerators.cpp
@@ -16,7 +16,7 @@ std::string WorldGenerators::getDefaultGeneratorID() {
     return "core:default";
 }
 
-std::unique_ptr<WorldGenerator> WorldGenerators::createGenerator(std::string id, const Content* content) {
+std::unique_ptr<WorldGenerator> WorldGenerators::createGenerator(const std::string& id, const Content* content) {
     auto found = generators.find(id);
     if (found == generators.end()) {
         throw std::runtime_error("unknown generator id: "+id);

--- a/src/world/WorldGenerators.hpp
+++ b/src/world/WorldGenerators.hpp
@@ -22,7 +22,7 @@ public:
     static std::string getDefaultGeneratorID();
 
     static std::unique_ptr<WorldGenerator> createGenerator(
-        std::string id, const Content* content
+        const std::string &id, const Content *content
     );
 };
 


### PR DESCRIPTION
- Changed several function parameters to be passed by const reference to avoid unnecessary copying.
- Addressed clang-tidy warnings related to parameter copying for better performance.
- Ensured all methods called on these parameters are compatible with const references.
- Improved overall efficiency and readability of the codebase.
- Modified functions to use std::move when setting class members to avoid unnecessary copies