### PR TITLE
Add support for `parent` field in block/item/entity json definitions

### DIFF
--- a/src/content/ContentBuilder.hpp
+++ b/src/content/ContentBuilder.hpp
@@ -44,6 +44,14 @@ public:
         defs[id] = std::make_unique<T>(id);
         return *defs[id];
     }
+    // Only fetch existing definition, return null otherwise.
+    T* get(const std::string& id) {
+        auto found = defs.find(id);
+        if (found != defs.end()) {
+            return &*found->second;
+        }
+        return nullptr;
+    }
 
     auto build() {
         return std::move(defs);

--- a/src/content/ContentLoader.cpp
+++ b/src/content/ContentLoader.cpp
@@ -481,23 +481,23 @@ void ContentLoader::load() {
 
     auto root = files::read_json(pack->getContentFile());
     std::vector<std::pair<std::string, std::string>> pendingDefs;
-    auto getJsonParent = [&](std::string prerix, std::string name) {
-        auto configFile =
-            pack->folder / fs::path(prerix + "/" + name + ".json");
-        std::string parent;
-        if (fs::exists(configFile)) {
-            auto root = files::read_json(configFile);
-            if (root->has("parent")) root->str("parent", parent);
-        }
-        return parent;
-    };
-    auto processName = [&](std::string name) {
+    auto getJsonParent = [this](const std::string& prefix, const std::string& name) {
+            auto configFile = pack->folder / fs::path(prefix + "/" + name + ".json");
+            std::string parent;
+            if (fs::exists(configFile)) {
+                auto root = files::read_json(configFile);
+                if (root->has("parent")) root->str("parent", parent);
+            }
+            return parent;
+        };
+    auto processName = [this](const std::string& name) {
         auto colon = name.find(':');
+        auto new_name = name;
         std::string full =
             colon == std::string::npos ? pack->id + ":" + name : name;
-        if (colon != std::string::npos) name[colon] = '/';
+        if (colon != std::string::npos) new_name[colon] = '/';
 
-        return std::make_pair(full, name);
+        return std::make_pair(full, new_name);
     };
 
     if (auto blocksarr = root->list("blocks")) {
@@ -628,7 +628,9 @@ void ContentLoader::load() {
         if (!pendingDefs.empty()) {
             // Handle circular dependencies or missing dependencies
             // You can log an error or throw an exception here if necessary
-            throw std::runtime_error("Unresolved entities dependencies detected.");
+            throw std::runtime_error(
+                "Unresolved entities dependencies detected."
+            );
         }
     }
 

--- a/src/content/ContentLoader.hpp
+++ b/src/content/ContentLoader.hpp
@@ -42,13 +42,13 @@ class ContentLoader {
 
     static void loadCustomBlockModel(Block& def, dynamic::Map* primitives);
     static void loadBlockMaterial(BlockMaterial& def, const fs::path& file);
-    static void loadBlock(
+    void loadBlock(
         Block& def, const std::string& name, const fs::path& file
     );
-    static void loadItem(
+    void loadItem(
         ItemDef& def, const std::string& name, const fs::path& file
     );
-    static void loadEntity(
+    void loadEntity(
         EntityDef& def, const std::string& name, const fs::path& file
     );
     void loadResources(ResourceType type, dynamic::List* list);

--- a/src/items/ItemDef.cpp
+++ b/src/items/ItemDef.cpp
@@ -5,3 +5,13 @@
 ItemDef::ItemDef(const std::string& name) : name(name) {
     caption = util::id_to_caption(name);
 }
+void ItemDef::cloneTo(ItemDef& dst) {
+    dst.caption = caption;
+    dst.stackSize = stackSize;
+    dst.generated = generated;
+    std::copy(&emission[0], &emission[3], dst.emission);
+    dst.iconType = iconType;
+    dst.icon = icon;
+    dst.placingBlock = placingBlock;
+    dst.scriptName = scriptName;
+}

--- a/src/items/ItemDef.hpp
+++ b/src/items/ItemDef.hpp
@@ -44,4 +44,5 @@ struct ItemDef {
 
     ItemDef(const std::string& name);
     ItemDef(const ItemDef&) = delete;
+    void cloneTo(ItemDef& dst);
 };

--- a/src/objects/EntityDef.cpp
+++ b/src/objects/EntityDef.cpp
@@ -1,0 +1,12 @@
+#include "EntityDef.hpp"
+void EntityDef::cloneTo(EntityDef& dst) {
+    dst.components = components;
+    dst.bodyType = bodyType;
+    dst.hitbox = hitbox;
+    dst.boxSensors = boxSensors;
+    dst.radialSensors = radialSensors;
+    dst.skeletonName = skeletonName;
+    dst.blocking = blocking;
+    dst.save = save;
+
+}

--- a/src/objects/EntityDef.hpp
+++ b/src/objects/EntityDef.hpp
@@ -24,12 +24,12 @@ struct EntityDef {
 
     /// @brief Hitbox size
     glm::vec3 hitbox {0.25f};
-    
+
     /// @brief 'aabb' sensors
     std::vector<std::pair<size_t, AABB>> boxSensors {};
     /// @brief 'radius' sensors
     std::vector<std::pair<size_t, float>> radialSensors {};
-    
+
     /// @brief Skeleton ID
     std::string skeletonName = name;
 
@@ -56,4 +56,6 @@ struct EntityDef {
 
     EntityDef(const std::string& name) : name(name) {}
     EntityDef(const EntityDef&) = delete;
+    void cloneTo(EntityDef& dst);
 };
+

--- a/src/voxels/Block.cpp
+++ b/src/voxels/Block.cpp
@@ -64,7 +64,8 @@ const BlockRotProfile BlockRotProfile::NONE {
         {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},  // West
         {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},  // Up
         {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},  // Down
-    }};
+    }
+};
 
 const BlockRotProfile BlockRotProfile::PIPE {
     "pipe",
@@ -75,7 +76,8 @@ const BlockRotProfile BlockRotProfile::PIPE {
         {{0, 0, -1}, {1, 0, 0}, {0, -1, 0}},   // West
         {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},     // Up
         {{1, 0, 0}, {0, -1, 0}, {0, 0, -1}},   // Down
-    }};
+    }
+};
 
 const BlockRotProfile BlockRotProfile::PANE {
     "pane",
@@ -84,7 +86,8 @@ const BlockRotProfile BlockRotProfile::PANE {
         {{0, 0, -1}, {0, 1, 0}, {1, 0, 0}},   // East
         {{-1, 0, 0}, {0, 1, 0}, {0, 0, -1}},  // South
         {{0, 0, 1}, {0, 1, 0}, {-1, 0, 0}},   // West
-    }};
+    }
+};
 
 Block::Block(const std::string& name)
     : name(name),
@@ -95,10 +98,43 @@ Block::Block(const std::string& name)
           TEXTURE_NOTFOUND,
           TEXTURE_NOTFOUND,
           TEXTURE_NOTFOUND,
-          TEXTURE_NOTFOUND} {
+          TEXTURE_NOTFOUND
+      } {
 }
 
 Block::Block(std::string name, const std::string& texture)
     : name(std::move(name)),
       textureFaces {texture, texture, texture, texture, texture, texture} {
+}
+void Block::cloneTo(Block& dst) {
+    dst.caption = caption;
+    for (int i = 0; i < 6; i++) {
+            dst.textureFaces[i] = textureFaces[i];
+    }
+    dst.modelTextures = modelTextures;
+    dst.modelBoxes = modelBoxes;
+    dst.modelExtraPoints = modelExtraPoints;
+    dst.modelUVs = modelUVs;
+    dst.material = material;
+    std::copy(&emission[0], &emission[3], dst.emission);
+    dst.size = size;
+    dst.model = model;
+    dst.lightPassing = lightPassing;
+    dst.skyLightPassing = skyLightPassing;
+    dst.shadeless = shadeless;
+    dst.ambientOcclusion = ambientOcclusion;
+    dst.obstacle = obstacle;
+    dst.selectable = selectable;
+    dst.replaceable = replaceable;
+    dst.breakable = breakable;
+    dst.rotatable = rotatable;
+    dst.grounded = grounded;
+    dst.hidden = hidden;
+    dst.hitboxes = hitboxes;
+    dst.rotations = rotations;
+    dst.pickingItem = pickingItem;
+    dst.scriptName = scriptName;
+    dst.uiLayout = uiLayout;
+    dst.inventorySize = inventorySize;
+    dst.tickInterval = tickInterval;
 }

--- a/src/voxels/Block.hpp
+++ b/src/voxels/Block.hpp
@@ -211,6 +211,8 @@ public:
     Block(const std::string& name);
     Block(std::string name, const std::string& texture);
     Block(const Block&) = delete;
+
+    void cloneTo(Block& dst);
 };
 
 inline glm::ivec3 get_ground_direction(const Block& def, int rotation) {


### PR DESCRIPTION
ItemDef/EntityDef/Block: Add method `cloneTo` to definition to other definition
ContentBuilder: Add method `get` to get definition or nullptr
ContentLoader: Add functionality to clone from definition specified in `parent` field in json