### PR TITLE
block model "x" preview fix

### DIFF
--- a/src/graphics/render/BlocksPreview.cpp
+++ b/src/graphics/render/BlocksPreview.cpp
@@ -102,6 +102,7 @@ std::unique_ptr<ImageData> BlocksPreview::draw(
             }
             break;
         case BlockModel::xsprite: {
+            shader->uniformMatrix("u_apply", glm::translate(glm::mat4(1.0f), offset));
             glm::vec3 right = glm::normalize(glm::vec3(1.f, 0.f, -1.f));
             batch->sprite(
                 right*float(size)*0.43f+glm::vec3(0, size*0.4f, 0), 


### PR DESCRIPTION
Фикс сдвига матрицы предпросмотра блока
До
![image](https://github.com/user-attachments/assets/6333971f-4e8a-4161-8dc7-fd26847cfb09)
После
![image](https://github.com/user-attachments/assets/6966f3a9-f9a7-41fe-88d6-3df75b168f07)
