### PR TITLE
console bug fix

### DIFF
--- a/res/layouts/console.xml.lua
+++ b/res/layouts/console.xml.lua
@@ -27,7 +27,7 @@ function on_history_up()
 end
 
 function on_history_down()
-    if history_pointer == #history-1 then
+    if history_pointer >= #history-1 then
         return
     end
     history_pointer = history_pointer + 1


### PR DESCRIPTION
До этих изменений, при попытке пролистать консоль вниз, если консоль была пуста, выводилась ошибка. Довольно старый баг, но руки дошли только сейчас (баг фикс в один символ)

```
[E] 2024/10/26 22:49:24.445+0300 [                 lua] [string "res\scripts\stdlib.lua"]:54: string expected at 4
stack traceback:
        [C]: in function 'setattr'
        [string "res\scripts\stdlib.lua"]:54: in function '__newindex'
        [string "res\layouts\console.xml.lua"]:34: in function 'on_history_down'
        [string "res\layouts\console.xml"]:1: in main chunk
```
