### PR TITLE
add lua function block/unblock bindings

### DIFF
--- a/src/logic/scripting/lua/libs/libcore.cpp
+++ b/src/logic/scripting/lua/libs/libcore.cpp
@@ -60,6 +60,8 @@ static int l_close_world(lua::State* L) {
     if (save_world) {
         controller->saveWorld();
     }
+    // unblock all bindings
+    Events::enableBindings();
     // destroy LevelScreen and run quit callbacks
     engine->setScreen(nullptr);
     // create and go to menu screen

--- a/src/logic/scripting/lua/libs/libinput.cpp
+++ b/src/logic/scripting/lua/libs/libinput.cpp
@@ -133,23 +133,14 @@ static int l_reset_bindings(lua::State*) {
     return 0;
 }
 
-static void enableBinding(std::string& bindname, bool enable) {
+static int l_enable_binding(lua::State* L) {
+    std::string bindname = lua::require_string(L, 1);
+    bool enable = lua::toboolean(L, 2);
     const auto& bind = Events::bindings.find(bindname);
     if (bind == Events::bindings.end()) {
         throw std::runtime_error("unknown binding " + util::quote(bindname));
     }
     Events::bindings[bindname].enable = enable;
-}
-
-static int l_enable_binding(lua::State* L) {
-    std::string bindname = lua::require_string(L, 1);
-    enableBinding(bindname, true);
-    return 0;
-}
-
-static int l_disable_binding(lua::State* L) {
-    std::string bindname = lua::require_string(L, 1);
-    enableBinding(bindname, false);
     return 0;
 }
 
@@ -164,5 +155,4 @@ const luaL_Reg inputlib[] = {
     {"is_pressed", lua::wrap<l_is_pressed>},
     {"reset_bindings", lua::wrap<l_reset_bindings>},
     {"enable_binding", lua::wrap<l_enable_binding>},
-    {"disable_binding", lua::wrap<l_disable_binding>},
     {NULL, NULL}};

--- a/src/logic/scripting/lua/libs/libinput.cpp
+++ b/src/logic/scripting/lua/libs/libinput.cpp
@@ -133,6 +133,26 @@ static int l_reset_bindings(lua::State*) {
     return 0;
 }
 
+static void enableBinding(std::string& bindname, bool enable) {
+    const auto& bind = Events::bindings.find(bindname);
+    if (bind == Events::bindings.end()) {
+        throw std::runtime_error("unknown binding " + util::quote(bindname));
+    }
+    Events::bindings[bindname].enable = enable;
+}
+
+static int l_enable_binding(lua::State* L) {
+    std::string bindname = lua::require_string(L, 1);
+    enableBinding(bindname, true);
+    return 0;
+}
+
+static int l_disable_binding(lua::State* L) {
+    std::string bindname = lua::require_string(L, 1);
+    enableBinding(bindname, false);
+    return 0;
+}
+
 const luaL_Reg inputlib[] = {
     {"keycode", lua::wrap<l_keycode>},
     {"mousecode", lua::wrap<l_mousecode>},
@@ -143,4 +163,6 @@ const luaL_Reg inputlib[] = {
     {"is_active", lua::wrap<l_is_active>},
     {"is_pressed", lua::wrap<l_is_pressed>},
     {"reset_bindings", lua::wrap<l_reset_bindings>},
+    {"enable_binding", lua::wrap<l_enable_binding>},
+    {"disable_binding", lua::wrap<l_disable_binding>},
     {NULL, NULL}};

--- a/src/window/Events.cpp
+++ b/src/window/Events.cpp
@@ -79,6 +79,7 @@ void Events::pollEvents() {
     for (auto& entry : bindings) {
         auto& binding = entry.second;
         if (!binding.enable) {
+            binding.state = false;
             continue;
         }
         binding.justChange = false;

--- a/src/window/Events.cpp
+++ b/src/window/Events.cpp
@@ -231,3 +231,10 @@ void Events::loadBindings(
         }
     }
 }
+
+void Events::enableBindings() {
+    for (auto& entry : bindings) {
+        auto& binding = entry.second;
+        binding.enable = true;
+    }
+}

--- a/src/window/Events.cpp
+++ b/src/window/Events.cpp
@@ -78,6 +78,9 @@ void Events::pollEvents() {
 
     for (auto& entry : bindings) {
         auto& binding = entry.second;
+        if (!binding.enable) {
+            continue;
+        }
         binding.justChange = false;
 
         bool newstate = false;

--- a/src/window/Events.hpp
+++ b/src/window/Events.hpp
@@ -60,4 +60,5 @@ public:
         const std::string& filename, const std::string& source,
         BindType bindType
     );
+    static void enableBindings();
 };

--- a/src/window/input.hpp
+++ b/src/window/input.hpp
@@ -137,6 +137,7 @@ struct Binding {
     int code;
     bool state = false;
     bool justChange = false;
+    bool enable = true;
 
     Binding() = default;
     Binding(inputtype type, int code) : type(type), code(code) {


### PR DESCRIPTION
Добавлена возможность заблокировать из Lua скрипта использование выбранной настройки управления игрока.

Например: input.disable_binding("movement.left") заблокирует движение игрока влево.
input.enable_binding("movement.left") разблокирует обратно.

Структуре Binding добавлено поле enable. По умолчанию равно true.
Метод pollEvents класса Events теперь не обрабатывает нажатие биндов, у которых enable равен false.

При выходе из мира все бинды принимают значение enable true. Это сделано на случай, что игрок выйдет из мира до разблокировки бинда.

Классу Events добавлен метод enableBindings.
Вызывается в функции l_close_world.

Нововведение сделано по запросу мододелов.
