### PR TITLE
add dayCycle stop

### DIFF
--- a/res/layouts/pages/settings_reset.xml.lua
+++ b/res/layouts/pages/settings_reset.xml.lua
@@ -7,6 +7,7 @@ function reset(category)
 		reset_graphics()
 	elseif category == "ctl" then
 		reset_control()
+		world.set_day_cycle(false)
 	end
 end
 

--- a/src/frontend/debug_panel.cpp
+++ b/src/frontend/debug_panel.cpp
@@ -184,6 +184,18 @@ std::shared_ptr<UINode> create_debug_panel(
     }
     {
         auto checkbox = std::make_shared<FullCheckBox>(
+            L"Day Cycle", glm::vec2(400, 24)
+        );
+        checkbox->setSupplier([&]() {
+            return worldInfo.dayCycle;
+        });
+        checkbox->setConsumer([&](bool checked) {
+            worldInfo.dayCycle = checked;
+        });
+        panel->add(checkbox);
+    }
+    {
+        auto checkbox = std::make_shared<FullCheckBox>(
             L"Show Chunk Borders", glm::vec2(400, 24)
         );
         checkbox->setSupplier([=]() {

--- a/src/logic/scripting/lua/libs/libworld.cpp
+++ b/src/logic/scripting/lua/libs/libworld.cpp
@@ -49,6 +49,12 @@ static int l_get_list(lua::State* L) {
     return 1;
 }
 
+static int l_set_day_cycle(lua::State* L) {
+    bool flag = lua::toboolean(L, 1);
+    require_world_info().dayCycle = flag;
+    return 0;
+}
+
 static int l_get_total_time(lua::State* L) {
     return lua::pushnumber(L, require_world_info().totalTime);
 }
@@ -100,6 +106,7 @@ static int l_get_generator(lua::State* L) {
 const luaL_Reg worldlib[] = {
     {"get_list", lua::wrap<l_get_list>},
     {"get_total_time", lua::wrap<l_get_total_time>},
+    {"set_day_cycle", lua::wrap<l_set_day_cycle>},
     {"get_day_time", lua::wrap<l_get_day_time>},
     {"set_day_time", lua::wrap<l_set_day_time>},
     {"set_day_time_speed", lua::wrap<l_set_day_time_speed>},

--- a/src/world/World.cpp
+++ b/src/world/World.cpp
@@ -40,8 +40,10 @@ World::~World() {
 }
 
 void World::updateTimers(float delta) {
-    info.daytime += delta * info.daytimeSpeed * DAYIME_SPECIFIC_SPEED;
-    info.daytime = std::fmod(info.daytime, 1.0f);
+    if (info.dayCycle) {
+        info.daytime += delta * info.daytimeSpeed * DAYIME_SPECIFIC_SPEED;
+        info.daytime = std::fmod(info.daytime, 1.0f);
+    }
     info.totalTime += delta;
 }
 
@@ -219,6 +221,7 @@ void WorldInfo::deserialize(const dv::value& root) {
         auto& timeobj = root["time"];
         daytime = timeobj["day-time"].asNumber();
         daytimeSpeed = timeobj["day-time-speed"].asNumber();
+        dayCycle = timeobj["day-cycle"].asBoolean();
         totalTime = timeobj["total-time"].asNumber();
     }
     if (root.has("weather")) {
@@ -242,6 +245,7 @@ dv::value WorldInfo::serialize() const {
     auto& timeobj = root.object("time");
     timeobj["day-time"] = daytime;
     timeobj["day-time-speed"] = daytimeSpeed;
+    timeobj["day-cycle"] = dayCycle;
     timeobj["total-time"] = totalTime;
 
     auto& weatherobj = root.object("weather");

--- a/src/world/World.hpp
+++ b/src/world/World.hpp
@@ -37,6 +37,9 @@ struct WorldInfo : public Serializable {
     // looking bad
     float daytimeSpeed = 1.0f;
 
+    /// @breif on/off Day/night loop timer
+    bool dayCycle = true;
+
     /// @brief total time passed in the world (not depending on daytimeSpeed)
     double totalTime = 0.0;
 


### PR DESCRIPTION
Добавлена возможность остановить цикл смены дня и ночи.
Да, раньше это можно было сделать через установку множителя скорости в ноль. Но теперь можно приостановить время не теряя прежний множитель его скорости.

Добавлена кнопка в меню F3, позволяющая остановить цикл смены дня и ночи.
Добавлена lua-функция set_day_cycle(), позволяющая включить/выключить цикл смены дня и ночи.

Структуре WorldInfo добавлено поле dayCycle по умолчанию равное true.
Оно записывается в файл world.json и считывается из него.

"time": {
    "total-time": 21728.3180450112,
    "day-time": 0.339981943368912,
    "day-time-speed": 1,
    "day-cycle": true
}

Изменение потребует конвертации мира. Без конвертации мир не загрузится. При необходимости можно конвертировать в ручную: дописать в файл world.json //"day-cycle": true//.

Нововведение сделано по запросу игроков.