### PR TITLE
Windows build bug fix

### DIFF
--- a/src/util/platform.cpp
+++ b/src/util/platform.cpp
@@ -12,6 +12,7 @@
 
 #ifdef _WIN32
 #include <Windows.h>
+#pragma comment(lib, "winmm.lib")
 
 void platform::configure_encoding() {
     // set utf-8 encoding to console output


### PR DESCRIPTION
Добавлена строка "#pragma comment(lib, "winmm.lib")".
Без неё Visual studio выдаёт ошибки сборки на последней на данный момент версии проекта.

Сборка начата в 15:51...
1>------ Сборка начата: проект: VoxelEngine-Cpp, Конфигурация: Debug x64 ------
1>platform.cpp
1>platform.obj : error LNK2019: ссылка на неразрешенный внешний символ __imp_timeGetDevCaps в функции "public: __cdecl <lambda_fbe8d8f4adeb690512d95fc5b7e56e4e>::operator()(void)const " (??R<lambda_fbe8d8f4adeb690512d95fc5b7e56e4e>@@QEBA@XZ).
1>platform.obj : error LNK2019: ссылка на неразрешенный внешний символ __imp_timeBeginPeriod в функции "void __cdecl platform::sleep(unsigned __int64)" (?sleep@platform@@YAX_K@Z).
1>platform.obj : error LNK2019: ссылка на неразрешенный внешний символ __imp_timeEndPeriod в функции "void __cdecl platform::sleep(unsigned __int64)" (?sleep@platform@@YAX_K@Z).
1>C:\Users\Пользователь\Documents\GitHub\VoxelEngine-Cpp\build\x64\Debug\VoxelEngine-Cpp.exe : fatal error LNK1120: неразрешенных внешних элементов: 3
1>Сборка проекта "VoxelEngine-Cpp.vcxproj" завершена с ошибкой.
========== Сборка: успешно выполнено — 0 , со сбоем — 1, в актуальном состоянии — 0, пропущено — 0 ==========
========== Сборка завершено в 15:52 и заняло 03,653 с ==========