### PR TITLE
Correction of the button location in the content_menu

### DIFF
--- a/res/layouts/pages/content_menu.xml
+++ b/res/layouts/pages/content_menu.xml
@@ -3,7 +3,7 @@
         <!-- content is generated in script -->
     </panel>
     <button pos='15,430' size='440,40' onclick='menu:back()'>@Back</button>
-    <button pos='460,430' size='440,40' onclick='core.open_folder("user:content")'>@Open content folder</button>
+    <button pos='485,430' size='500,40' onclick='core.open_folder("user:content")'>@Open content folder</button>
 
     <panel id='content_info' pos='485,15' size='440,406' color='0' max-length='406' scrollable='true'>
         <label>@Creator</label>

--- a/res/layouts/pages/content_menu.xml.lua
+++ b/res/layouts/pages/content_menu.xml.lua
@@ -1,7 +1,4 @@
 function on_open(params)
-    if params then
-        mode = params.mode
-    end
     refresh()
 end
 


### PR DESCRIPTION
Исправлено расположение кнопки открытия папки контента в Content_menu, а так же удалены лишние строки кода из скрипта лояута

Было:
![image](https://github.com/user-attachments/assets/5e58dfb2-e632-4d9d-8d5e-e83f265753e6)

Стало:
![image](https://github.com/user-attachments/assets/ffe704c0-5007-42d4-bee8-4b6f31ae19f6)
