### PR TITLE
Add missing curl dependency to nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     flake-utils.lib.eachDefaultSystem (system: {
         devShells.default = with nixpkgs.legacyPackages.${system}; mkShell {
           nativeBuildInputs = [ cmake pkg-config ];
-          buildInputs = [ glm glfw glew zlib libpng libvorbis openal luajit  ]; # libglvnd
+          buildInputs = [ glm glfw glew zlib libpng libvorbis openal luajit curl ]; # libglvnd
           packages = [ glfw mesa freeglut entt ];
           LD_LIBRARY_PATH = "${wayland}/lib:$LD_LIBRARY_PATH";
         };


### PR DESCRIPTION
I tried to build master as is with `nix develop`:
```
[user@mainpc:~/dev/VoxelEngine-Cpp]$ ./run.sh 
-- The C compiler identification is GNU 13.3.0
-- The CXX compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/62zpnw69ylcfhcpy1di8152zlzmbls91-gcc-wrapper-13.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/62zpnw69ylcfhcpy1di8152zlzmbls91-gcc-wrapper-13.3.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenGL: /nix/store/rcvwvfgk5dkwc3a8sza5q0351h8axbkh-libglvnd-1.7.0/lib/libOpenGL.so
-- Found GLEW: /nix/store/b45zbjld6bxcsqx6rxzlc2ls1mfc6122-glew-2.2.0-dev/lib/cmake/glew/glew-config.cmake
-- Found OpenAL: /nix/store/cjv1kd9sz3m8944zy77hpl8g13y6hhbi-openal-soft-1.23.1/lib/libopenal.so
-- Found ZLIB: /nix/store/phnpfqk1j35nil4hqgaslqm9a1q2gffy-zlib-1.3.1/lib/libz.so (found version "1.3.1")
-- Found PNG: /nix/store/9np0hdwai3jyn1skbyqj7hr2m5r99307-libpng-apng-1.6.43/lib/libpng.so (found version "1.6.43")
CMake Error at /nix/store/aqckch626lg0vxh41dabyzrq0jx7gdk5-cmake-3.29.6/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)
Call Stack (most recent call first):
  /nix/store/aqckch626lg0vxh41dabyzrq0jx7gdk5-cmake-3.29.6/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /nix/store/aqckch626lg0vxh41dabyzrq0jx7gdk5-cmake-3.29.6/share/cmake-3.29/Modules/FindCURL.cmake:196 (find_package_handle_standard_args)
  src/CMakeLists.txt:18 (find_package)
```

Adding curl to list of dependencies in flakes.nix fixes that.