### PR TITLE
AreaMap2D getHeight typo fix

### DIFF
--- a/src/util/AreaMap2D.hpp
+++ b/src/util/AreaMap2D.hpp
@@ -180,7 +180,7 @@ namespace util {
         }
 
         TCoord getHeight() const {
-            return sizeX;
+            return sizeY;
         }
 
         const std::vector<T>& getBuffer() const {


### PR DESCRIPTION
Return sizeY instead of sizeX.