### PR TITLE
add cmake-format.py and formating all cmake files

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,3 @@
+tab_size = 4
+enable_sort = True
+autosort = True

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,18 +8,20 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  # We use two types linking: for clang build is static (vcpkg triplet x64-windows-static)
-  # and for msvc build is dynamic linking (vcpkg triplet x64-windows)
-  # By default CMAKE_MSVC_RUNTIME_LIBRARY set by MultiThreaded$<$<CONFIG:Debug>:Debug>DLL
-  if (VCPKG_TARGET_TRIPLET MATCHES "static")
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-  endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # We use two types linking: for clang build is static (vcpkg triplet
+    # x64-windows-static) and for msvc build is dynamic linking (vcpkg triplet
+    # x64-windows) By default CMAKE_MSVC_RUNTIME_LIBRARY set by
+    # MultiThreaded$<$<CONFIG:Debug>:Debug>DLL
+    if(VCPKG_TARGET_TRIPLET MATCHES "static")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    endif()
 endif()
 
 add_subdirectory(src)
 add_executable(${PROJECT_NAME} src/main.cpp)
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_include_directories(${PROJECT_NAME}
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 if(VOXELENGINE_BUILD_APPDIR)
     include(${CMAKE_CURRENT_SOURCE_DIR}/dev/cmake/BuildAppdir.cmake)
@@ -27,33 +29,44 @@ endif()
 
 if(MSVC)
     if(NOT CMAKE_BUILD_TYPE)
-      set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+        set(CMAKE_BUILD_TYPE
+            Release
+            CACHE STRING "Build type" FORCE)
     endif()
-    if((CMAKE_BUILD_TYPE EQUAL "Release") OR (CMAKE_BUILD_TYPE EQUAL "RelWithDebInfo"))
-      target_compile_options(${PROJECT_NAME} PRIVATE /W4 /MT /O2)
+    if((CMAKE_BUILD_TYPE EQUAL "Release") OR (CMAKE_BUILD_TYPE EQUAL
+                                              "RelWithDebInfo"))
+        target_compile_options(${PROJECT_NAME} PRIVATE /W4 /MT /O2)
     else()
-      target_compile_options(${PROJECT_NAME} PRIVATE /W4)
+        target_compile_options(${PROJECT_NAME} PRIVATE /W4)
     endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /source-charset:UTF-8 /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} /source-charset:UTF-8 /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
+    )
 else()
-  target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra
-    # additional warnings
-    -Wformat-nonliteral -Wcast-align
-    -Wpointer-arith -Wundef
-    -Wwrite-strings -Wno-unused-parameter)
-  if (CMAKE_BUILD_TYPE MATCHES "Debug")
-    target_compile_options(${PROJECT_NAME} PRIVATE -Og)
-  endif()
-  if (WIN32)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-  endif()
+    target_compile_options(
+        ${PROJECT_NAME}
+        PRIVATE -Wall
+                -Wextra
+                # additional warnings
+                -Wformat-nonliteral
+                -Wcast-align
+                -Wpointer-arith
+                -Wundef
+                -Wwrite-strings
+                -Wno-unused-parameter)
+    if(CMAKE_BUILD_TYPE MATCHES "Debug")
+        target_compile_options(${PROJECT_NAME} PRIVATE -Og)
+    endif()
+    if(WIN32)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+    endif()
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -lstdc++fs")
 endif()
 
-if (WIN32)
+if(WIN32)
     target_link_libraries(${PROJECT_NAME} VoxelEngineSrc winmm)
 endif()
 
@@ -61,14 +74,13 @@ target_link_libraries(${PROJECT_NAME} VoxelEngineSrc ${CMAKE_DL_LIBS})
 
 # Deploy res to build dir
 add_custom_command(
-  TARGET ${PROJECT_NAME} 
-  POST_BUILD 
-  COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different 
-          ${CMAKE_CURRENT_SOURCE_DIR}/res 
-          $<TARGET_FILE_DIR:${PROJECT_NAME}>/res
-  )
+    TARGET ${PROJECT_NAME}
+    POST_BUILD
+    COMMAND
+        ${CMAKE_COMMAND} -E copy_directory_if_different
+        ${CMAKE_CURRENT_SOURCE_DIR}/res $<TARGET_FILE_DIR:${PROJECT_NAME}>/res)
 
-if (VOXELENGINE_BUILD_TESTS)
+if(VOXELENGINE_BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(${PROJECT_NAME} STATIC ${SOURCES} ${HEADERS})
 
 find_package(OpenGL REQUIRED)
 find_package(GLEW REQUIRED)
-if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     # specific for vcpkg
     find_package(OpenAL CONFIG REQUIRED)
     set(OPENAL_LIBRARY OpenAL::OpenAL)
@@ -20,17 +20,19 @@ endif()
 find_package(ZLIB REQUIRED)
 find_package(PNG REQUIRED)
 find_package(CURL REQUIRED)
-if (NOT APPLE)
+if(NOT APPLE)
     find_package(EnTT REQUIRED)
 endif()
 
 set(LIBS "")
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    # Use directly linking to lib instead PkgConfig (because pkg-config dont install on windows as default) 
-    # TODO: Do it with findLua.
-    if (MSVC)
-        set(LUA_INCLUDE_DIR "$ENV{VCPKG_ROOT}/packages/luajit_${VCPKG_TARGET_TRIPLET}/include/luajit")
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # Use directly linking to lib instead PkgConfig (because pkg-config dont
+    # install on windows as default) TODO: Do it with findLua.
+    if(MSVC)
+        set(LUA_INCLUDE_DIR
+            "$ENV{VCPKG_ROOT}/packages/luajit_${VCPKG_TARGET_TRIPLET}/include/luajit"
+        )
         find_package(Lua REQUIRED)
     else()
         # Used for mingw-clang cross compiling from msys2
@@ -49,7 +51,7 @@ elseif(APPLE)
     set(LUA_LIBRARIES "/opt/homebrew/lib/libluajit-5.1.a")
     message(STATUS "LUA Libraries: ${LUA_LIBRARIES}")
     message(STATUS "LUA Include Dir: ${LUA_INCLUDE_DIR}")
-    
+
     set(VORBISLIB ${VORBIS_LDFLAGS})
     message(STATUS "Vorbis Lib: ${VORBIS_LDFLAGS}")
 else()
@@ -70,4 +72,16 @@ endif()
 include_directories(${LUA_INCLUDE_DIR})
 include_directories(${CURL_INCLUDE_DIR})
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(${PROJECT_NAME} ${LIBS} glfw OpenGL::GL ${OPENAL_LIBRARY} GLEW::GLEW ZLIB::ZLIB PNG::PNG CURL::libcurl ${VORBISLIB} ${LUA_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(
+    ${PROJECT_NAME}
+    ${LIBS}
+    glfw
+    OpenGL::GL
+    ${OPENAL_LIBRARY}
+    GLEW::GLEW
+    ZLIB::ZLIB
+    PNG::PNG
+    CURL::libcurl
+    ${VORBISLIB}
+    ${LUA_LIBRARIES}
+    ${CMAKE_DL_LIBS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,23 +8,19 @@ find_package(GTest)
 
 add_executable(${PROJECT_NAME} ${SOURCES})
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-target_link_libraries(
-  ${PROJECT_NAME}
-  VoxelEngineSrc
-  GTest::gtest_main
-)
+target_include_directories(${PROJECT_NAME}
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(${PROJECT_NAME} VoxelEngineSrc GTest::gtest_main)
 
-# HACK: copy res to test/ folder for fixing problem compatibility MultiConfig and non
-# MultiConfig builds. Delete in future and use only root res folder
-# Also this resolve problem with ctests, because it set cwd to CMAKE_CURRENT_BINARY_DIR
+# HACK: copy res to test/ folder for fixing problem compatibility MultiConfig
+# and non MultiConfig builds. Delete in future and use only root res folder Also
+# this resolve problem with ctests, because it set cwd to
+# CMAKE_CURRENT_BINARY_DIR
 add_custom_command(
-  TARGET ${PROJECT_NAME} 
-  POST_BUILD 
-  COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different 
-          ${CMAKE_SOURCE_DIR}/res 
-          ${CMAKE_CURRENT_BINARY_DIR}/res
-  )
+    TARGET ${PROJECT_NAME}
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+            ${CMAKE_SOURCE_DIR}/res ${CMAKE_CURRENT_BINARY_DIR}/res)
 
 include(GoogleTest)
 gtest_discover_tests(${PROJECT_NAME})

--- a/vctest/CMakeLists.txt
+++ b/vctest/CMakeLists.txt
@@ -8,24 +8,35 @@ add_executable(${PROJECT_NAME} ${SOURCES})
 
 if(MSVC)
     if(NOT CMAKE_BUILD_TYPE)
-      set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+        set(CMAKE_BUILD_TYPE
+            Release
+            CACHE STRING "Build type" FORCE)
     endif()
-    if((CMAKE_BUILD_TYPE EQUAL "Release") OR (CMAKE_BUILD_TYPE EQUAL "RelWithDebInfo"))
-      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Release>:Release>")
-      target_compile_options(${PROJECT_NAME} PRIVATE /W4 /MT /O2)
+    if((CMAKE_BUILD_TYPE EQUAL "Release") OR (CMAKE_BUILD_TYPE EQUAL
+                                              "RelWithDebInfo"))
+        set(CMAKE_MSVC_RUNTIME_LIBRARY
+            "MultiThreaded$<$<CONFIG:Release>:Release>")
+        target_compile_options(${PROJECT_NAME} PRIVATE /W4 /MT /O2)
     else()
-      target_compile_options(${PROJECT_NAME} PRIVATE /W4)
+        target_compile_options(${PROJECT_NAME} PRIVATE /W4)
     endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 else()
-  target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra
-    -Wformat-nonliteral -Wcast-align
-    -Wpointer-arith -Wundef
-    -Wwrite-strings -Wno-unused-parameter)
+    target_compile_options(
+        ${PROJECT_NAME}
+        PRIVATE -Wall
+                -Wextra
+                -Wformat-nonliteral
+                -Wcast-align
+                -Wpointer-arith
+                -Wundef
+                -Wwrite-strings
+                -Wno-unused-parameter)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -lstdc++fs")
 endif()
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src ${CMAKE_DL_LIBS})
+target_include_directories(
+    ${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src ${CMAKE_DL_LIBS})


### PR DESCRIPTION
Добавил cmake-format, подробнее почитать [тут](https://cmake-format.readthedocs.io/en/latest/format-usage.html)

Правила форматирования описаны в .cmake-format.py
Для использования нужно иметь питон в системе (и в PATH'е для Windows) и установить пакет cmakelang
```bash
pip install cmakelang
```