### PR TITLE
Bug fix gui.template

### DIFF
--- a/res/scripts/stdlib.lua
+++ b/res/scripts/stdlib.lua
@@ -194,7 +194,7 @@ function gui.template(name, params)
     text = text:gsub("if%s*=%s*'%%{%w+}'", "if=''")
     text = text:gsub("if%s*=%s*\"%%{%w+}\"", "if=\"\"")
     -- remove unsolved properties: attr='%{var}'
-    text = text:gsub("%w+%s*=%s*'%%{%w+}'%s?", "")
+    text = text:gsub("%s*%S+='%%{[^}]+}'%s*", " ")
     text = text:gsub('%s*%S+="%%{[^}]+}"%s*', " ")
     return text
 end

--- a/res/scripts/stdlib.lua
+++ b/res/scripts/stdlib.lua
@@ -195,7 +195,7 @@ function gui.template(name, params)
     text = text:gsub("if%s*=%s*\"%%{%w+}\"", "if=\"\"")
     -- remove unsolved properties: attr='%{var}'
     text = text:gsub("%w+%s*=%s*'%%{%w+}'%s?", "")
-    text = text:gsub("%w+%s*=%s*\"%%{%w+}\"%s?", "")
+    text = text:gsub('%s*%S+="%%{[^}]+}"%s*', " "))
     return text
 end
 

--- a/res/scripts/stdlib.lua
+++ b/res/scripts/stdlib.lua
@@ -195,7 +195,7 @@ function gui.template(name, params)
     text = text:gsub("if%s*=%s*\"%%{%w+}\"", "if=\"\"")
     -- remove unsolved properties: attr='%{var}'
     text = text:gsub("%w+%s*=%s*'%%{%w+}'%s?", "")
-    text = text:gsub('%s*%S+="%%{[^}]+}"%s*', " "))
+    text = text:gsub('%s*%S+="%%{[^}]+}"%s*', " ")
     return text
 end
 


### PR DESCRIPTION
Исправен баг с поведением gui.template в ситуации:

```lua

--Было
text =  " z-index='%{index}' position-func='%{position_func}' "

text = text:gsub("%w+%s*=%s*'%%{%w+}'%s?", "")
text = text:gsub("%w+%s*=%s*\"%%{%w+}\"%s?", "")
print(text) -- " z-position-func='%{position_func}'"

--Стало
text =  " z-index='%{index}' position-func='%{position_func}' "

text = text:gsub("%s*%S+='%%{[^}]+}'%s*", "")
text = text:gsub('%s*%S+="%%{[^}]+}"%s*', " ")
print(text) -- " "
```