### PR TITLE
detect_locale crash fix

### DIFF
--- a/src/util/platform.cpp
+++ b/src/util/platform.cpp
@@ -65,17 +65,21 @@ int platform::get_process_id() {
 #else // _WIN32
 
 #include <unistd.h>
+#include "frontend/locale.hpp"
 
 void platform::configure_encoding() {
 }
 
 std::string platform::detect_locale() {
-    std::string programLocaleName = setlocale(LC_ALL, nullptr);
-    std::string preferredLocaleName =
+    const char* const programLocaleName = setlocale(LC_ALL, nullptr);
+    const char* const preferredLocaleName =
         setlocale(LC_ALL, "");  // locale name format: ll_CC.encoding
-    setlocale(LC_ALL, programLocaleName.c_str());
+    if (programLocaleName && preferredLocaleName) {
+        setlocale(LC_ALL, programLocaleName);
 
-    return preferredLocaleName.substr(0, 5);
+        return std::string(preferredLocaleName, 5);
+    }
+    return langs::FALLBACK_DEFAULT;
 }
 
 void platform::sleep(size_t millis) {


### PR DESCRIPTION
Исправил вылет при неудачном обнаружении локали на linux-based системах при первом запуске

Не уверен что возвращать langs::FALLBACK_DEFAULT при неудаче корректное решение, возможно стоит заменить на какой-то "undefined" или "not_set"