### PR TITLE
Bug fix content_menu.xml.lua

### DIFF
--- a/res/layouts/pages/content_menu.xml.lua
+++ b/res/layouts/pages/content_menu.xml.lua
@@ -127,7 +127,7 @@ end
 
 local function has_valid_config(id)
     if not file.exists("config:" .. id) then
-        return
+        return false
     end
 
     local files = file.list("config:" .. id)


### PR DESCRIPTION
До баг фикса, шестерёнка была активна, если хотя бы один файл был в папке конфигов мода, наплевав на то, является ли он конфигом, тут это пофикшено