### PR TITLE
Canvas: Reuse image data instead of fetching it every time off the GPU

### DIFF
--- a/src/graphics/ui/elements/Canvas.cpp
+++ b/src/graphics/ui/elements/Canvas.cpp
@@ -5,8 +5,9 @@
 #include "graphics/core/Texture.hpp"
 
 gui::Canvas::Canvas(ImageFormat inFormat, glm::uvec2 inSize) : UINode(inSize) {
-    ImageData data {inFormat, inSize.x, inSize.y};
-    mTexture = Texture::from(&data);
+    auto data = std::make_shared<ImageData>(inFormat, inSize.x, inSize.y);
+    mTexture = Texture::from(data.get());
+    mData = std::move(data);
 }
 
 void gui::Canvas::draw(const DrawContext& pctx, const Assets& assets) {

--- a/src/graphics/ui/elements/Canvas.hpp
+++ b/src/graphics/ui/elements/Canvas.hpp
@@ -15,11 +15,15 @@ namespace gui {
 
         void draw(const DrawContext& pctx, const Assets& assets) override;
 
-        [[nodiscard]] std::shared_ptr<::Texture> texture() const {
+        [[nodiscard]] auto texture() const {
             return mTexture;
+        }
+
+        [[nodiscard]] auto data() const {
+            return mData;
         }
     private:
         std::shared_ptr<::Texture> mTexture;
-        std::unique_ptr<ImageData> mData;
+        std::shared_ptr<ImageData> mData;
     };
 }

--- a/src/logic/scripting/lua/libs/libgui.cpp
+++ b/src/logic/scripting/lua/libs/libgui.cpp
@@ -326,7 +326,7 @@ static int p_get_src(UINode* node, lua::State* L) {
 
 static int p_get_data(UINode* node, lua::State* L) {
     if (auto canvas = dynamic_cast<Canvas*>(node)) {
-        return lua::newuserdata<lua::LuaCanvas>(L, canvas->texture());
+        return lua::newuserdata<lua::LuaCanvas>(L, canvas->texture(), canvas->data());
     }
     return 0;
 }

--- a/src/logic/scripting/lua/lua_custom_types.hpp
+++ b/src/logic/scripting/lua/lua_custom_types.hpp
@@ -96,22 +96,29 @@ namespace lua {
 
     class LuaCanvas : public Userdata {
     public:
-        explicit LuaCanvas(std::shared_ptr<Texture> inTexture);
+        explicit LuaCanvas(
+            std::shared_ptr<Texture> inTexture,
+            std::shared_ptr<ImageData> inData
+        );
         ~LuaCanvas() override = default;
 
         const std::string& getTypeName() const override {
             return TYPENAME;
         }
 
-        [[nodiscard]] Texture& texture() const { return *mTexture; }
+        [[nodiscard]] auto& texture() const {
+            return *mTexture;
+        }
 
-        [[nodiscard]] ImageData& data() const { return *mData; }
+        [[nodiscard]] auto& data() const {
+            return *mData;
+        }
 
         static int createMetatable(lua::State*);
         inline static std::string TYPENAME = "Canvas";
     private:
         std::shared_ptr<Texture> mTexture;
-        std::unique_ptr<ImageData> mData;
+        std::shared_ptr<ImageData> mData;
     };
     static_assert(!std::is_abstract<LuaCanvas>());
 }

--- a/src/logic/scripting/lua/usertypes/lua_type_canvas.cpp
+++ b/src/logic/scripting/lua/usertypes/lua_type_canvas.cpp
@@ -7,9 +7,10 @@
 
 using namespace lua;
 
-LuaCanvas::LuaCanvas(std::shared_ptr<Texture> inTexture)
-    : mTexture(std::move(inTexture)) {
-    mData = mTexture->readData();
+LuaCanvas::LuaCanvas(
+    std::shared_ptr<Texture> inTexture, std::shared_ptr<ImageData> inData
+)
+    : mTexture(std::move(inTexture)), mData(std::move(inData)) {
 }
 
 union RGBA {
@@ -29,8 +30,8 @@ static RGBA* get_at(const ImageData& data, uint x, uint y) {
 }
 
 static RGBA* get_at(State* L, uint x, uint y) {
-    if (auto texture = touserdata<LuaCanvas>(L, 1)) {
-        return get_at(texture->data(), x, y);
+    if (auto canvas = touserdata<LuaCanvas>(L, 1)) {
+        return get_at(canvas->data(), x, y);
     }
     return nullptr;
 }
@@ -76,8 +77,8 @@ static int l_set(State* L) {
 }
 
 static int l_update(State* L) {
-    if (auto texture = touserdata<LuaCanvas>(L, 1)) {
-        texture->texture().reload(texture->data());
+    if (auto canvas = touserdata<LuaCanvas>(L, 1)) {
+        canvas->texture().reload(canvas->data());
     }
     return 0;
 }

--- a/src/logic/scripting/lua/usertypes/lua_type_canvas.cpp
+++ b/src/logic/scripting/lua/usertypes/lua_type_canvas.cpp
@@ -14,8 +14,10 @@ LuaCanvas::LuaCanvas(
 }
 
 union RGBA {
-    uint8_t rgba[4];
-    uint32_t raw;
+    struct {
+        uint8_t r, g, b, a;
+    };
+    uint32_t rgba;
 };
 
 static RGBA* get_at(const ImageData& data, uint index) {
@@ -41,7 +43,7 @@ static int l_at(State* L) {
     auto y = static_cast<uint>(tointeger(L, 3));
 
     if (auto pixel = get_at(L, x, y)) {
-        return pushinteger(L, pixel->raw);
+        return pushinteger(L, pixel->rgba);
     }
 
     return 0;
@@ -54,19 +56,19 @@ static int l_set(State* L) {
     if (auto pixel = get_at(L, x, y)) {
         switch (gettop(L)) {
             case 4:
-                pixel->raw = static_cast<uint>(tointeger(L, 4));
+                pixel->rgba = static_cast<uint>(tointeger(L, 4));
                 return 1;
             case 6:
-                pixel->rgba[0] = static_cast<ubyte>(tointeger(L, 4));
-                pixel->rgba[1] = static_cast<ubyte>(tointeger(L, 5));
-                pixel->rgba[2] = static_cast<ubyte>(tointeger(L, 6));
-                pixel->rgba[3] = 255;
+                pixel->r = static_cast<ubyte>(tointeger(L, 4));
+                pixel->g = static_cast<ubyte>(tointeger(L, 5));
+                pixel->b = static_cast<ubyte>(tointeger(L, 6));
+                pixel->a = 255;
                 return 1;
             case 7:
-                pixel->rgba[0] = static_cast<ubyte>(tointeger(L, 4));
-                pixel->rgba[1] = static_cast<ubyte>(tointeger(L, 5));
-                pixel->rgba[2] = static_cast<ubyte>(tointeger(L, 6));
-                pixel->rgba[3] = static_cast<ubyte>(tointeger(L, 7));
+                pixel->r = static_cast<ubyte>(tointeger(L, 4));
+                pixel->g = static_cast<ubyte>(tointeger(L, 5));
+                pixel->b = static_cast<ubyte>(tointeger(L, 6));
+                pixel->a = static_cast<ubyte>(tointeger(L, 7));
                 return 1;
             default:
                 return 0;
@@ -97,7 +99,7 @@ static int l_meta_index(State* L) {
     auto& data = texture->data();
     if (isnumber(L, 2)) {
         if (auto pixel = get_at(data, static_cast<uint>(tointeger(L, 2)))) {
-            return pushinteger(L, pixel->raw);
+            return pushinteger(L, pixel->rgba);
         }
     }
     if (isstring(L, 2)) {
@@ -123,7 +125,7 @@ static int l_meta_newindex(State* L) {
     auto& data = texture->data();
     if (isnumber(L, 2) && isnumber(L, 3)) {
         if (auto pixel = get_at(data, static_cast<uint>(tointeger(L, 2)))) {
-            pixel->raw = static_cast<uint>(tointeger(L, 3));
+            pixel->rgba = static_cast<uint>(tointeger(L, 3));
             return 1;
         }
         return 1;


### PR DESCRIPTION
Before that change, every access to the canvas' `data` property created a new, unique `ImageData` object, resulting in a noticeable lag spike. Because of that, it also had an undocumented requirement to reuse the same object for every call to its methods.