### PR TITLE
fix: image render & LabelCache::update crash

### DIFF
--- a/src/graphics/ui/elements/Label.cpp
+++ b/src/graphics/ui/elements/Label.cpp
@@ -51,7 +51,7 @@ void LabelCache::update(std::wstring_view text, bool multiline, bool wrap) {
             if (text[i] == L'\n') {
                 lines.push_back(LineScheme {i+1, false});
                 len = 0;
-            } else if (i > 0 && wrap && text[i+1] != L'\n') {
+            } else if (i > 0 && i+1 < text.length() && wrap && text[i+1] != L'\n') {
                 size_t width = font->calcWidth(text, i-len-1, i-(i-len)+2);
                 if (width >= wrapWidth) {
                     // starting a fake line

--- a/src/graphics/ui/elements/UINode.cpp
+++ b/src/graphics/ui/elements/UINode.cpp
@@ -160,9 +160,9 @@ CursorShape UINode::getCursor() const {
 
 glm::vec2 UINode::calcPos() const {
     if (parent) {
-        return pos + parent->calcPos() + parent->getContentOffset();
+        return glm::ivec2(pos + parent->calcPos() + parent->getContentOffset());
     }
-    return pos;
+    return glm::ivec2(pos);
 }
 
 void UINode::scrolled(int value) {


### PR DESCRIPTION
Из за плавающей точки в UINode::calcPos картинки (и не только) криво рендерились
![image](https://github.com/user-attachments/assets/dce45234-e6a7-4d9f-bd3a-5c549508c93a)
![image](https://github.com/user-attachments/assets/4e133cb7-1204-46b0-963b-8652d4d9691a)
