### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,11 @@ cd vcpkg
 ```
 After installing **vcpkg**, setup env variable **VCPKG_ROOT** and add it to **PATH**:
 ```PowerShell
-$env:VCPKG_ROOT = "C:\path\to\vcpkg"
-$env:PATH = "$env:VCPKG_ROOT;$env:PATH"
+[Environment]::SetEnvironmentVariable(
+  "VCPKG_ROOT", 
+  "C:\path\to\vcpkg", 
+  "User"
+)
 ```
 >[!TIP]
 >For troubleshooting you can read full [documentation](https://learn.microsoft.com/ru-ru/vcpkg/get_started/get-started?pivots=shell-powershell) for **vcpkg**


### PR DESCRIPTION
Старый способ установки переменных работает только в текущей сессии где они были установлены, то есть после открытия нового экземпляра терминала VCPKG_ROOT будет отсутствовать, мой способ установки исправляет эту проблему