### PR TITLE
Fix "error: attempt to call global '__load_script' (a nil value)"

### DIFF
--- a/res/scripts/stdmin.lua
+++ b/res/scripts/stdmin.lua
@@ -185,7 +185,7 @@ local internal_locked = false
 --     Example `base:scripts/tests.lua`
 --
 -- nocache - ignore cached script, load anyway
-local function __load_script(path, nocache, env)
+function __load_script(path, nocache, env)
     local packname, filename = parse_path(path)
 
     if internal_locked and (packname == "res" or packname == "core") 


### PR DESCRIPTION
```cmd
[E] 2025/11/20 15:33:04.640+0300  [           lua-debug] error: attempt to call global '__load_script' (a nil value)
stack traceback:
[string "core:scripts/stdlib.lua"]:541: in function '__load_script'
[string "core:scripts/stdlib.lua"]:644: in function 'load_script'
```