### PR TITLE
Add gravity vector

### DIFF
--- a/doc/en/scripting/ecs.md
+++ b/doc/en/scripting/ecs.md
@@ -89,6 +89,8 @@ body:set_size(size: vec3)
 body:get_gravity_scale() -> number
 -- Sets the gravity multiplier
 body:set_gravity_scale(scale: number)
+-- Sets the gravity vector
+body:set_gravity_vec(scale: number)
 
 -- Returns the linear velocity attenuation multiplier (used to simulate air resistance and friction)
 body:get_linear_damping() -> number

--- a/doc/ru/scripting/ecs.md
+++ b/doc/ru/scripting/ecs.md
@@ -89,6 +89,8 @@ body:set_size(size: vec3)
 body:get_gravity_scale() -> number
 -- Устанавливает множитель гравитации
 body:set_gravity_scale(scale: number)
+-- Устанавливает вектор гравитации
+body:set_gravity_vec(scale: number)
 
 -- Возвращает множитель затухания линейной скорости (используется для имитации сопротивления воздуха и трения)
 body:get_linear_damping() -> number

--- a/res/modules/internal/stdcomp.lua
+++ b/res/modules/internal/stdcomp.lua
@@ -22,6 +22,7 @@ local Rigidbody = {__index={
     set_size=function(self, v) return __rigidbody.set_size(self.eid, v) end,
     get_gravity_scale=function(self) return __rigidbody.get_gravity_scale(self.eid) end,
     set_gravity_scale=function(self, s) return __rigidbody.set_gravity_scale(self.eid, s) end,
+    set_gravity_vec=function(self, s) return __rigidbody.set_gravity_vec(self.eid, s) end,
     get_linear_damping=function(self) return __rigidbody.get_linear_damping(self.eid) end,
     set_linear_damping=function(self, f) return __rigidbody.set_linear_damping(self.eid, f) end,
     is_vdamping=function(self) return __rigidbody.is_vdamping(self.eid) end,

--- a/res/scripts/stdcmd.lua
+++ b/res/scripts/stdcmd.lua
@@ -313,3 +313,24 @@ console.add_command(
         return "available presets:" .. presets
     end
 )
+
+console.add_command(
+    "player.gravity player:int x:num y:num z:num",
+    "Set gravity vector",
+    function(args, kwargs)
+        local pid = args[1]
+        local x, y, z = args[2], args[3], args[4]
+        local eid = player.get_entity(pid)
+            if not eid then
+                return "player has no entity"
+            end
+            
+            local ent = entities.get(eid)
+            if not ent then
+                return "entity not found"
+            end
+            
+            ent.rigidbody:set_gravity_vec({x, y, z})
+            return string.format(" gravity vector set to [%.1f, %.1f, %.1f]", x, y, z)
+    end, true
+)

--- a/src/logic/scripting/lua/libs/lib__rigidbody.cpp
+++ b/src/logic/scripting/lua/libs/lib__rigidbody.cpp
@@ -56,10 +56,19 @@ static int l_set_gravity_scale(lua::State* L) {
     if (auto entity = get_entity(L, 1)) {
         auto& hitbox = entity->getRigidbody().hitbox;
         if (lua::istable(L, 2)) {
-            hitbox.gravityScale = lua::tovec3(L, 2).y;
+            // hitbox.gravityScale = lua::tovec3(L, 2).y;
+            hitbox.gravityVec = lua::tovec3(L, 2);
         } else {
             hitbox.gravityScale = lua::tonumber(L, 2);
         }
+    }
+    return 0;
+}
+
+static int l_set_gravity_vec(lua::State* L) {
+    if (auto entity = get_entity(L, 1)) {
+        auto& hitbox = entity->getRigidbody().hitbox;
+        hitbox.gravityVec = lua::tovec3(L, 2);
     }
     return 0;
 }
@@ -159,6 +168,7 @@ const luaL_Reg rigidbodylib[] = {
     {"set_size", lua::wrap<l_set_size>},
     {"get_gravity_scale", lua::wrap<l_get_gravity_scale>},
     {"set_gravity_scale", lua::wrap<l_set_gravity_scale>},
+    {"set_gravity_vec", lua::wrap<l_set_gravity_vec>},
     {"get_linear_damping", lua::wrap<l_get_linear_damping>},
     {"set_linear_damping", lua::wrap<l_set_linear_damping>},
     {"is_vdamping", lua::wrap<l_is_vdamping>},

--- a/src/physics/Hitbox.hpp
+++ b/src/physics/Hitbox.hpp
@@ -57,6 +57,7 @@ struct Hitbox {
     float verticalDamping = 1.0f;
     bool grounded = false;
     float gravityScale = 1.0f;
+    glm::vec3 gravityVec = glm::vec3(0.0f, 0.0f, 0.0f);
     bool crouching = false;
 
     Hitbox(BodyType type, glm::vec3 position, glm::vec3 halfsize);

--- a/src/physics/PhysicsSolver.cpp
+++ b/src/physics/PhysicsSolver.cpp
@@ -32,7 +32,8 @@ void PhysicsSolver::step(
     glm::vec3& pos = hitbox.position;
     glm::vec3& vel = hitbox.velocity;
     float gravityScale = hitbox.gravityScale;
-    
+    glm::vec3 gravityVec = hitbox.gravityVec;
+
     bool prevGrounded = hitbox.grounded;
     hitbox.grounded = false;
     for (uint i = 0; i < substeps; i++) {
@@ -40,13 +41,13 @@ void PhysicsSolver::step(
         float py = pos.y;
         float pz = pos.z;
         
-        vel += gravity * dt * gravityScale;
+        vel += (gravity + gravityVec) * dt * gravityScale;
         if (hitbox.type == BodyType::DYNAMIC) {
             colisionCalc(chunks, hitbox, vel, pos, half, 
                          (prevGrounded && gravityScale > 0.0f) ? 0.5f : 0.0f);
         }
 
-        pos += vel * dt + gravity * gravityScale * dt * dt * 0.5f;
+        pos += vel * dt + (gravity + gravityVec) * gravityScale * dt * dt * 0.5f;
         if (hitbox.grounded && pos.y < py) {
             pos.y = py;
         }


### PR DESCRIPTION
Добавил вектор гравитации в:

- `Hitbox.cpp` новый параметр `gravityVec`
- `PhysicsSolver.cpp` где к пареметру `gravity `добавляется `gravityVec`
- `lib__rigidbody.cpp` добавлен сеттер `set_gravity_vec` для `gravityVec`
- `stdcmd.lua` новая внутриигровя команда для изменения `gravityVec` в консоли


``` stdcmd.lua
console.add_command(
    "player.gravity player:int x:num y:num z:num",
    "Set gravity vector",
    function(args, kwargs)
        local pid = args[1]
        local x, y, z = args[2], args[3], args[4]
        local eid = player.get_entity(pid)
            if not eid then
                return "player has no entity"
            end
            
            local ent = entities.get(eid)
            if not ent then
                return "entity not found"
            end
            
            ent.rigidbody:set_gravity_vec({x, y, z})
            return string.format(" gravity vector set to [%.1f, %.1f, %.1f]", x, y, z)
    end, true
)
```
- Дальше буду менять логику использования Y сущности, когда Y = Глобальный Y, относительно которого определяется прыжок, ось поворота камеры, на логику, где Y будет зависеть от направления гравитации.
- Работа по направлению кубических чанков

<img width="964" height="749" alt="image" src="https://github.com/user-attachments/assets/e6ad745a-301c-4f0a-a5b1-034e8defafc3" />

