### PR TITLE
Update debug panel

### DIFF
--- a/src/frontend/debug_panel.cpp
+++ b/src/frontend/debug_panel.cpp
@@ -83,7 +83,6 @@ std::shared_ptr<UINode> create_debug_panel(
     static float drawCallsAvgLong = drawCalls;
     static std::wstring drawCallsString = L"";
 
-
     static const float AVG_ALPHA = 0.3;
 
     static size_t lastTotalDownload = 0;
@@ -152,8 +151,10 @@ std::shared_ptr<UINode> create_debug_panel(
     panel->add(create_label(gui, []() {
         drawCalls = MeshStats::drawCalls;
         MeshStats::drawCalls = 0;
-        return L"draw-calls: " + std::to_wstring(drawCalls) + L" ( avg: " +
-               drawCallsString + L" )";
+        auto drawCallsStr = std::to_wstring(drawCalls);
+        drawCallsStr.resize(6, ' ');
+        return L"draw-calls: " + drawCallsStr +
+               L" ( avg: " + drawCallsString + L" )";
     }));
     panel->add(create_label(gui, []() {
         return L"    min/max: " +


### PR DESCRIPTION
изменения:
- добавлено: среднее значение для fps и draw calls
- исправлено: из иа отрисовки тени через кадр, draw calls всё време меняеться между 2 значениями: <img width="681" height="426" alt="изображение" src="https://github.com/user-attachments/assets/a4369cfe-0ca4-4cb5-8647-202bc37254bf" />
---
расшифровка обновлённых значение:
- fps: avgFast / avgLong / min / max
- drawCalls: avgLong / min / max
