### PR TITLE
remove: HandsRednerer: update func exec in render

### DIFF
--- a/src/graphics/render/HandsRenderer.cpp
+++ b/src/graphics/render/HandsRenderer.cpp
@@ -28,7 +28,6 @@ void HandsRenderer::renderHands(
     const auto& config = *skeleton.config;
 
     modelBatch.setLightsOffset(camera.position);
-    config.update(skeleton, glm::mat4(1.0f), glm::vec3(), glm::vec3(1.0f));
     config.render(
         assets,
         modelBatch,


### PR DESCRIPTION
Удалён вызов `update` т.к. в сед. строке вызываеться `render` в котором первой строкой идёт вызов `update`.
То есть ранее `update` вызывался 2 раза подряд.