### PR TITLE
Add player flight test script

### DIFF
--- a/dev/tests/player_flight.lua
+++ b/dev/tests/player_flight.lua
@@ -1,0 +1,41 @@
+local pid = 0
+local world_name = "player_flight_test"
+
+app.reconfig_packs({"base"}, {})
+app.new_world(
+    world_name,
+    "111111111111",
+    "core:default",
+    pid
+)
+
+player.create("test", pid)
+player.set_flight(pid, true)
+player.set_pos(pid, 0, 100, 0)
+
+app.close_world(true)
+
+local function process()
+    app.open_world(world_name)
+
+    for i=1, 100 do
+        local x, y, z = player.get_pos(pid)
+        print("Player Y is " .. tostring(y))
+        app.tick()
+    end
+
+    app.close_world(true)
+end
+
+process()
+process()
+process()
+
+app.open_world(world_name)
+local x, y, z = player.get_pos(pid)
+print("Player Y is " .. tostring(y))
+
+app.close_world(true)
+app.delete_world(world_name)
+
+assert(100 - y < 1)


### PR DESCRIPTION
Заметил сначала в одиночке, что при перезаходе в мир, движок просто игнорирует то, что созданный аватар находится в полёте и он просто падает на землю (хотя те же функции всё ещё пишут, что полёт у аватара включен)

Поэтому решил написать тест, где он ведёт себя немного иначе: вместо того, чтобы постоянно падать, будто бы флай выключен, он падает первые несколько секунд после запуска, а после останавливается

Поведение такое немного рандомное, поэтому в тесте 3 итерации, вместо одной