### PR TITLE
Portability fixes from a Nintendo 3DS port (alignment UB, non-GL builds, Lua without FFI, small screens)

### DIFF
--- a/res/content/base/modules/util.lua
+++ b/res/content/base/modules/util.lua
@@ -24,12 +24,10 @@ local function calc_loot(loot_table)
             if loot.min and loot.max then
                 count = math.random(loot.min, loot.max)
             end
-            if count == 0 then
-                goto continue
+            if count ~= 0 then
+                table.insert(results, {item=item.index(loot.item), count=count})
             end
-            table.insert(results, {item=item.index(loot.item), count=count})
         end
-        ::continue::
     end
     return results
 end

--- a/res/modules/internal/bytearray.lua
+++ b/res/modules/internal/bytearray.lua
@@ -1,3 +1,14 @@
+-- The FFI may be missing entirely (interpreter without LuaJIT) or present
+-- but unable to resolve C symbols (statically linked host without dynamic
+-- symbol lookup); probe it before committing to the FFI implementation.
+local ffi_usable = ffi ~= nil and pcall(function()
+    ffi.cdef("void* malloc(size_t); void free(void*);")
+    ffi.C.free(ffi.C.malloc(8))
+end)
+if not ffi_usable then
+    return require "core:internal/bytearray_fallback"
+end
+
 local MIN_CAPACITY = 8
 local _type = type
 local FFI = ffi

--- a/res/modules/internal/bytearray_fallback.lua
+++ b/res/modules/internal/bytearray_fallback.lua
@@ -1,0 +1,218 @@
+-- Plain-Lua implementation of the Bytearray API from bytearray.lua.
+-- Used when the FFI is unavailable (interpreter without LuaJIT) or
+-- non-functional (no access to C symbols in the host binary).
+-- Slower than the FFI version, but keeps scripts portable.
+
+-- On Lua 5.1 the __len/__index metamethods for '#' and indexing only work
+-- on userdata, which newproxy provides; newer interpreters dropped
+-- newproxy but support the metamethods on plain tables.
+local function make_object()
+    if newproxy then
+        local proxy = newproxy(true)
+        return proxy, getmetatable(proxy)
+    end
+    local mt = {}
+    return setmetatable({}, mt), mt
+end
+
+local function new_bytearray(init)
+    local proxy, mt = make_object()
+    local data = {}
+    local size = 0
+
+    local methods
+    local function append(_, b)
+        if type(b) == "number" then
+            size = size + 1
+            data[size] = b % 256
+        else
+            for i = 1, #b do
+                size = size + 1
+                data[size] = b[i] % 256
+            end
+        end
+    end
+    local function insert(_, index, b)
+        if b == nil then
+            b = index
+            index = size + 1
+        end
+        if index <= 0 or index > size + 1 then
+            return
+        end
+        local elems = type(b) == "number" and 1 or #b
+        for i = size, index, -1 do
+            data[i + elems] = data[i]
+        end
+        if type(b) == "number" then
+            data[index] = b % 256
+        else
+            for i = 1, #b do
+                data[index + i - 1] = b[i] % 256
+            end
+        end
+        size = size + elems
+    end
+    local function remove(_, index, elems)
+        if index <= 0 or index > size then
+            return
+        end
+        elems = elems or 1
+        if index + elems > size then
+            elems = size - index + 1
+        end
+        for i = index, size - elems do
+            data[i] = data[i + elems]
+        end
+        for i = size - elems + 1, size do
+            data[i] = nil
+        end
+        size = size - elems
+    end
+    methods = {
+        append = append,
+        insert = insert,
+        remove = remove,
+        trim = function() end,
+        clear = function() data = {}; size = 0 end,
+        reserve = function() end,
+        get_capacity = function() return size end,
+        slice = function(_, offset, length)
+            offset = offset or 1
+            length = length or (size - offset + 1)
+            local out = {}
+            for i = 1, length do
+                out[i] = data[offset + i - 1]
+            end
+            return new_bytearray(out)
+        end,
+        __is_bytearray = true,
+        __data = function() return data, size end,
+    }
+    mt.__index = function(_, key)
+        if type(key) == "string" then
+            return methods[key]
+        end
+        if key <= 0 or key > size then
+            return nil
+        end
+        return data[key]
+    end
+    mt.__newindex = function(_, key, value)
+        if type(key) == "string" then
+            return
+        end
+        if key == size + 1 then
+            append(nil, value)
+        elseif key >= 1 and key <= size then
+            data[key] = value % 256
+        end
+    end
+    mt.__len = function() return size end
+    mt.__tostring = function()
+        return string.format("Bytearray[%s]{...}", size)
+    end
+    local function iter()
+        local i = 0
+        return function()
+            i = i + 1
+            if i <= size then
+                return i, data[i]
+            end
+        end
+    end
+    mt.__ipairs = iter
+    mt.__pairs = iter
+
+    if type(init) == "string" then
+        for i = 1, #init do
+            size = size + 1
+            data[size] = init:byte(i)
+        end
+    elseif type(init) == "table" then
+        for i = 1, #init do
+            size = size + 1
+            data[size] = init[i] % 256
+        end
+    elseif type(init) == "number" then
+        for i = 1, init do
+            data[i] = 0
+        end
+        size = init
+    end
+    return proxy
+end
+
+local FFIBytearray = setmetatable({}, {
+    __call = function(_, n) return new_bytearray(n) end
+})
+
+local function as_string(bytes)
+    if type(bytes) == "table" then
+        local out = {}
+        for i = 1, #bytes do
+            out[i] = string.char(bytes[i] % 256)
+        end
+        return table.concat(out)
+    end
+    local data, size = bytes.__data()
+    local out = {}
+    for i = 1, size do
+        out[i] = string.char(data[i])
+    end
+    return table.concat(out)
+end
+
+local function make_view(typesize, signed)
+    return function(bytes)
+        local view, mt = make_object()
+        local function get_len()
+            return math.floor(#bytes / typesize)
+        end
+        mt.__index = function(_, key)
+            if key == "size" then
+                return get_len()
+            end
+            if key <= 0 or key > get_len() then
+                return nil
+            end
+            local base = (key - 1) * typesize
+            local v = 0
+            for i = typesize, 1, -1 do
+                v = v * 256 + bytes[base + i]
+            end
+            if signed then
+                local max = 2 ^ (typesize * 8 - 1)
+                if v >= max then
+                    v = v - max * 2
+                end
+            end
+            return v
+        end
+        mt.__newindex = function(_, key, value)
+            if key <= 0 or key > get_len() then
+                return
+            end
+            local base = (key - 1) * typesize
+            if value < 0 then
+                value = value + 2 ^ (typesize * 8)
+            end
+            for i = 1, typesize do
+                bytes[base + i] = value % 256
+                value = math.floor(value / 256)
+            end
+        end
+        mt.__len = get_len
+        return view
+    end
+end
+
+return {
+    FFIBytearray = FFIBytearray,
+    FFIBytearray_as_string = as_string,
+    FFIBytearray_as_ptr = function() return "0" end,
+    FFIU16view = make_view(2, false),
+    FFII16view = make_view(2, true),
+    FFIU32view = make_view(4, false),
+    FFII32view = make_view(4, true),
+}

--- a/res/modules/internal/stdcomp.lua
+++ b/res/modules/internal/stdcomp.lua
@@ -125,19 +125,17 @@ return {
     end,
     update = function(tps, parts, part)
         for uid, entity in pairs(entities) do
-            if uid % parts ~= part then
-                goto continue
-            end
-            for _, component in pairs(entity.components) do
-                local callback = component.on_update
-                if not component.__disabled and callback then
-                    local result, err = pcall(callback, tps)
-                    if err then
-                        debug.error(err)
+            if uid % parts == part then
+                for _, component in pairs(entity.components) do
+                    local callback = component.on_update
+                    if not component.__disabled and callback then
+                        local result, err = pcall(callback, tps)
+                        if err then
+                            debug.error(err)
+                        end
                     end
                 end
             end
-            ::continue::
         end
     end,
     physics_update = function(delta)

--- a/res/modules/internal/stream_providers/named_pipe.lua
+++ b/res/modules/internal/stream_providers/named_pipe.lua
@@ -1,5 +1,17 @@
 local FFI = ffi
 
+-- named pipes are implemented via the FFI; without a usable one
+-- (no LuaJIT / no C symbol access) the feature is unavailable
+local ffi_usable = FFI ~= nil and pcall(function()
+    FFI.cdef("void* malloc(size_t); void free(void*);")
+    FFI.C.free(FFI.C.malloc(8))
+end)
+if not ffi_usable then
+    return function()
+        error("named pipes are not available on this platform")
+    end
+end
+
 if FFI.os == "Windows" then
     return require "core:internal/stream_providers/named_pipe_windows"
 else

--- a/res/scripts/internal_events.lua
+++ b/res/scripts/internal_events.lua
@@ -10,53 +10,49 @@ block.__perform_ticks = function(delta)
         entry.timer = entry.timer + delta
         local steps = math.floor(entry.timer / entry.delta * #entry / 3)
         steps = math.min(steps, #entry / 3)
-        if steps == 0 then
-            goto continue
+        if steps ~= 0 then
+            entry.timer = 0.0
+            entry.pointer = entry.pointer % #entry
+            local event = entry.event
+            local tps = entry.tps
+            for i=1, steps do
+                local x = entry[entry.pointer + 1]
+                local y = entry[entry.pointer + 2]
+                local z = entry[entry.pointer + 3]
+                entry.pointer = (entry.pointer + 3) % #entry
+                events.emit(event, x, y, z, tps)
+            end
         end
-        entry.timer = 0.0
-        entry.pointer = entry.pointer % #entry
-        local event = entry.event
-        local tps = entry.tps
-        for i=1, steps do
-            local x = entry[entry.pointer + 1]
-            local y = entry[entry.pointer + 2]
-            local z = entry[entry.pointer + 3]
-            entry.pointer = (entry.pointer + 3) % #entry
-            events.emit(event, x, y, z, tps)
-        end
-        ::continue::
     end
     for id, queue in pairs(present_queues) do
         queue.timer = queue.timer + delta
         local steps = math.floor(queue.timer / queue.delta * #queue / 3)
         steps = math.min(steps, #queue / 3)
-        if steps == 0 then
-            goto continue
-        end
-        queue.timer = 0.0
-        local event = queue.event
-        local update_list = updating_blocks[id]
-        for i=1, steps do
-            local index = #queue - 2
-            if index <= 0 then
-                break
-            end
-            local x = queue[index]
-            local y = queue[index + 1]
-            local z = queue[index + 2]
+        if steps ~= 0 then
+            queue.timer = 0.0
+            local event = queue.event
+            local update_list = updating_blocks[id]
+            for i=1, steps do
+                local index = #queue - 2
+                if index <= 0 then
+                    break
+                end
+                local x = queue[index]
+                local y = queue[index + 1]
+                local z = queue[index + 2]
 
-            for j=1,3 do
-                table.remove(queue, index)
-            end
-            events.emit(event, x, y, z)
+                for j=1,3 do
+                    table.remove(queue, index)
+                end
+                events.emit(event, x, y, z)
 
-            if queue.updating then
-                table.insert(update_list, x)
-                table.insert(update_list, y)
-                table.insert(update_list, z)
+                if queue.updating then
+                    table.insert(update_list, x)
+                    table.insert(update_list, y)
+                    table.insert(update_list, z)
+                end
             end
         end
-        ::continue::
     end
 end
 
@@ -120,28 +116,20 @@ block.__process_register_events = function()
             table.insert(present_queue, x)
             table.insert(present_queue, y)
             table.insert(present_queue, z)
-            goto continue
-        end
-        if not is_updating then
-            goto continue
-        end
-        if is_register then
-            table.insert(list, x)
-            table.insert(list, y)
-            table.insert(list, z)
-        else
-            if not list then
-                goto continue
-            end
-            for j=1, #list, 3 do
-                if list[j] == x and list[j + 1] == y and list[j + 2] == z then
-                    for k=1,3 do
-                        table.remove(list, j)
+        elseif is_updating then
+            if is_register then
+                table.insert(list, x)
+                table.insert(list, y)
+                table.insert(list, z)
+            elseif list then
+                for j=1, #list, 3 do
+                    if list[j] == x and list[j + 1] == y and list[j + 2] == z then
+                        for k=1,3 do
+                            table.remove(list, j)
+                        end
                     end
-                    j = j - 3
                 end
             end
         end
-        ::continue::
     end
 end

--- a/res/scripts/stdlib.lua
+++ b/res/scripts/stdlib.lua
@@ -324,18 +324,24 @@ __vc_scripts_registry = require "core:internal/scripts_registry"
 file.open = require "core:internal/stream_providers/file"
 file.open_named_pipe = require "core:internal/stream_providers/named_pipe"
 
-if ffi.os == "Windows" then
-    ffi.cdef[[
-    unsigned long GetCurrentProcessId();
-    ]]
+local pid_ok = ffi ~= nil and pcall(function()
+    if ffi.os == "Windows" then
+        ffi.cdef[[
+        unsigned long GetCurrentProcessId();
+        ]]
 
-    os.pid = ffi.C.GetCurrentProcessId()
-else
-    ffi.cdef[[
-    int getpid(void);
-    ]]
+        os.pid = ffi.C.GetCurrentProcessId()
+    else
+        ffi.cdef[[
+        int getpid(void);
+        ]]
 
-    os.pid = ffi.C.getpid()
+        os.pid = ffi.C.getpid()
+    end
+end)
+if not pid_ok then
+    -- no usable FFI on this platform
+    os.pid = 0
 end
 
 require("core:io_stream").wrap_bytearray = require "core:internal/stream_providers/bytearray"

--- a/res/scripts/stdmin.lua
+++ b/res/scripts/stdmin.lua
@@ -265,16 +265,14 @@ function __scripts_cleanup(non_reset_packs)
     end
     for k, v in pairs(__cached_scripts) do
         local packname, _ = parse_path(k)
-        if table.has(non_reset_packs, packname) then
-            goto continue
+        if not table.has(non_reset_packs, packname) then
+            if packname ~= "core" then
+                debug.log("unloaded "..k)
+                __cached_scripts[k] = nil
+                package.loaded[k] = nil
+            end
+            __pack_envs[packname] = nil
         end
-        if packname ~= "core" then
-            debug.log("unloaded "..k)
-            __cached_scripts[k] = nil
-            package.loaded[k] = nil
-        end
-        __pack_envs[packname] = nil
-        ::continue::
     end
 end
 

--- a/res/scripts/stdmin.lua
+++ b/res/scripts/stdmin.lua
@@ -23,14 +23,22 @@ function crc32(bytes, chksum)
 
     local length = #bytes
     if type(bytes) == "table" then
-        local buffer_len = _ffi.new('int[1]', length)
-        local buffer = _ffi.new(
-            string.format("char[%s]", length)
-        )
-        for i=1, length do
-            buffer[i - 1] = bytes[i]
+        if _ffi then
+            local buffer_len = _ffi.new('int[1]', length)
+            local buffer = _ffi.new(
+                string.format("char[%s]", length)
+            )
+            for i=1, length do
+                buffer[i - 1] = bytes[i]
+            end
+            bytes = _ffi.string(buffer, buffer_len[0])
+        else
+            local chars = {}
+            for i=1, length do
+                chars[i] = string.char(bytes[i] % 256)
+            end
+            bytes = table.concat(chars)
         end
-        bytes = _ffi.string(buffer, buffer_len[0])
     end
     return _crc32(bytes, chksum)
 end

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -7,10 +7,20 @@
 #include "io/io.hpp"
 #include "coders/ogg.hpp"
 #include "coders/wav.hpp"
+#ifndef VC_NO_AL
 #include "AL/ALAudio.hpp"
+#endif
 #include "NoAudio.hpp"
 #include "debug/Logger.hpp"
 #include "util/ObjectsKeeper.hpp"
+
+#ifdef VC_AUDIO_CUSTOM_BACKEND
+namespace audio {
+    /// @brief Platform-provided audio backend factory
+    /// (implemented by ports built with VC_AUDIO_CUSTOM_BACKEND)
+    Backend* create_custom_backend(AudioSettings& settings);
+}
+#endif
 
 static debug::Logger logger("audio");
 
@@ -162,10 +172,18 @@ void audio::initialize(
     bool enabled, bool inputEnabled, AudioSettings& settings
 ) {
     enabled = enabled && settings.enabled.get();
+#ifndef VC_NO_AL
     if (enabled) {
         logger.info() << "initializing ALAudio backend";
         backend = ALAudio::create(settings).release();
     }
+#endif
+#ifdef VC_AUDIO_CUSTOM_BACKEND
+    if (enabled && backend == nullptr) {
+        logger.info() << "initializing custom audio backend";
+        backend = create_custom_backend(settings);
+    }
+#endif
     if (backend == nullptr) {
         if (enabled) {
             std::cerr << "could not to initialize audio" << std::endl;

--- a/src/coders/gzip.cpp
+++ b/src/coders/gzip.cpp
@@ -42,8 +42,13 @@ std::vector<ubyte> gzip::compress(const ubyte* src, size_t size) {
 
 std::vector<ubyte> gzip::decompress(const ubyte* src, size_t size) {
     // getting uncompressed data length from gzip footer
+    // (byte-by-byte: the footer is not aligned, dereferencing it as uint32
+    // is UB and produces garbage on strict-alignment targets)
     size_t decompressed_size =
-        *reinterpret_cast<const uint32_t*>(src + size - 4);
+        static_cast<size_t>(src[size - 4]) |
+        (static_cast<size_t>(src[size - 3]) << 8) |
+        (static_cast<size_t>(src[size - 2]) << 16) |
+        (static_cast<size_t>(src[size - 1]) << 24);
     std::vector<ubyte> buffer;
     buffer.resize(decompressed_size);
 

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -30,7 +30,13 @@ inline constexpr entityid_t ENTITY_NONE = 0;
 inline constexpr entityid_t ENTITY_AUTO = std::numeric_limits<entityid_t>::max();
 
 inline constexpr int CHUNK_W = 16;
-inline constexpr int CHUNK_H = 256;
+// Chunk height may be lowered at build time on memory-constrained
+// platforms (every loaded chunk stores CHUNK_VOL voxels + lightmaps).
+// Note: worlds are not portable between builds with different CHUNK_H.
+#ifndef VC_CHUNK_H
+#define VC_CHUNK_H 256
+#endif
+inline constexpr int CHUNK_H = VC_CHUNK_H;
 inline constexpr int CHUNK_D = 16;
 
 inline constexpr int EXTENDED_BLOCK_LIMIT = CHUNK_W; // must not be greater than chunk width and depth
@@ -62,7 +68,11 @@ inline constexpr uint vox_index(uint x, uint y, uint z, uint w=CHUNK_W, uint d=C
 }
 
 /// @brief pixel size of an item inventory icon
-inline constexpr int ITEM_ICON_SIZE = 48;
+/// (overridable at build time for low-resolution screens)
+#ifndef VC_ITEM_ICON_SIZE
+#define VC_ITEM_ICON_SIZE 48
+#endif
+inline constexpr int ITEM_ICON_SIZE = VC_ITEM_ICON_SIZE;
 
 inline constexpr int TRANSLUCENT_BLOCKS_SORT_INTERVAL = 8;
 

--- a/src/engine/EnginePaths.cpp
+++ b/src/engine/EnginePaths.cpp
@@ -63,9 +63,9 @@ EnginePaths::EnginePaths(CoreParameters& params)
         );
     }
     logger.info() << "executable path: " << platform::get_executable_path().string();
-    logger.info() << "resources folder: " << fs::canonical(resourcesFolder).u8string();
-    logger.info() << "user files folder: " << fs::canonical(userFilesFolder).u8string();
-    logger.info() << "project folder: " << fs::canonical(projectFolder).u8string();
+    logger.info() << "resources folder: " << fs::weakly_canonical(resourcesFolder).u8string();
+    logger.info() << "user files folder: " << fs::weakly_canonical(userFilesFolder).u8string();
+    logger.info() << "project folder: " << fs::weakly_canonical(projectFolder).u8string();
     
     if (!io::is_directory(CONTENT_FOLDER)) {
         io::create_directories(CONTENT_FOLDER);

--- a/src/frontend/LevelFrontend.cpp
+++ b/src/frontend/LevelFrontend.cpp
@@ -28,6 +28,7 @@ LevelFrontend::LevelFrontend(
       contentCache(std::make_unique<ContentGfxCache>(
           level.content, assets, settings.graphics
       )) {
+#ifndef VC_NO_GL
     assets.store(
         BlocksPreview::build(
             engine.getWindow(),
@@ -37,6 +38,7 @@ LevelFrontend::LevelFrontend(
         ),
         "block-previews"
     );
+#endif
 
     auto& currentPlayer = playerController.getPlayer();
     auto& assets = this->assets;

--- a/src/frontend/hud.cpp
+++ b/src/frontend/hud.cpp
@@ -385,9 +385,11 @@ void Hud::openInventory(bool playerInventory) {
         auto& content = frontend.getLevel().content;
         auto inventory = player.getInventory();
         auto inventoryDocument = assets.get<UiDocument>("core:inventory");
-        inventoryView = std::dynamic_pointer_cast<InventoryView>(inventoryDocument->getRoot());
-        inventoryView->bind(inventory, &content);
-        add(HudElement(HudElementMode::INVENTORY, inventoryDocument, inventoryView, false));
+        if (inventoryDocument != nullptr) {
+            inventoryView = std::dynamic_pointer_cast<InventoryView>(inventoryDocument->getRoot());
+            inventoryView->bind(inventory, &content);
+            add(HudElement(HudElementMode::INVENTORY, inventoryDocument, inventoryView, false));
+        }
     }
     gui.setActiveFrame(GUI::CORE_MAIN);
 }

--- a/src/frontend/hud.cpp
+++ b/src/frontend/hud.cpp
@@ -616,6 +616,7 @@ void Hud::draw(const DrawContext& ctx){
     auto batch = ctx.getBatch2D();
     batch->begin();
 
+#ifndef VC_NO_GL
     auto& uishader = assets.require<Shader>("ui");
     uishader.use();
     uishader.uniformMatrix("u_projview", uicamera->getProjView());
@@ -633,6 +634,7 @@ void Hud::draw(const DrawContext& ctx){
             chsizex, chsizey, 0, 0, 1, 1, 1, 1, 1, 1
         );
     }
+#endif
 }
 
 void Hud::updateElementsPosition(const glm::uvec2& viewport) {

--- a/src/frontend/hud.cpp
+++ b/src/frontend/hud.cpp
@@ -135,14 +135,23 @@ std::shared_ptr<InventoryView> Hud::createHotbar() {
     auto inventory = player.getInventory();
     auto& content = frontend.getLevel().content;
 
+    bool interactive = engine.getSettings().ui.hotbarInteractive.get();
     SlotLayout slotLayout(-1, glm::vec2(), false, false, nullptr, nullptr, nullptr);
+    if (interactive) {
+        // clicking/tapping a hotbar slot makes it the chosen one
+        auto* playerPtr = &player;
+        slotLayout.updateFunc = [playerPtr](uint index, ItemStack&) {
+            playerPtr->setChosenSlot(static_cast<int>(index));
+        };
+        slotLayout.taking = false;
+    }
     InventoryBuilder builder(gui);
     builder.addGrid(10, 10, glm::vec2(), glm::vec4(4), true, slotLayout);
     auto view = builder.build();
     view->setId("hud.hotbar");
     view->setOrigin(glm::vec2(view->getSize().x/2, 0));
     view->bind(inventory, &content);
-    view->setInteractive(false);
+    view->setInteractive(interactive);
     return view;
 }
 
@@ -352,11 +361,19 @@ void Hud::update(bool visible) {
     }
 
     const auto& windowSize = engine.getWindow().getSize();
+    bool compact = isCompactMode(windowSize);
     glm::vec2 caSize = contentAccessPanel->getSize();
     contentAccessPanel->setVisible(inventoryView != nullptr && showContentPanel);
+    if (compact && inventoryView) {
+        // no space for the inventory and the content access panel side
+        // by side: show one at a time, toggled by showContentPanel
+        inventoryView->setVisible(visible && !showContentPanel);
+    }
     contentAccessPanel->setSize(glm::vec2(caSize.x, windowSize.y));
     contentAccess->setMinSize(glm::vec2(1, windowSize.y));
-    hotbarView->setVisible(visible && !(secondUI && !inventoryView));
+    hotbarView->setVisible(
+        visible && !(secondUI && !inventoryView) &&
+        !(compact && inventoryOpen));
     darkOverlay->setVisible(isMenuOpen);
     menu.setVisible(isMenuOpen);
 
@@ -637,23 +654,46 @@ void Hud::draw(const DrawContext& ctx){
 #endif
 }
 
+bool Hud::isCompactMode(const glm::uvec2& viewport) const {
+    if (inventoryView == nullptr || !showContentPanel) {
+        return false;
+    }
+    float caWidth = contentAccess ? contentAccess->getSize().x : 0.0f;
+    return inventoryView->getSize().x + caWidth + 10 > viewport.x;
+}
+
 void Hud::updateElementsPosition(const glm::uvec2& viewport) {
     if (inventoryOpen) {
+        bool compact = isCompactMode(viewport);
         float caWidth = inventoryView && showContentPanel
                             ? contentAccess->getSize().x
                             : 0.0f;
-        contentAccessPanel->setPos(glm::vec2(viewport.x - caWidth, 0));
+        if (compact) {
+            // panels are shown one at a time (see Hud::update): center
+            // the content access panel instead of docking it right
+            contentAccessPanel->setPos(
+                glm::vec2((viewport.x - caWidth) / 2, 0));
+        } else {
+            contentAccessPanel->setPos(glm::vec2(viewport.x - caWidth, 0));
+        }
 
         glm::vec2 invSize = inventoryView ? inventoryView->getSize() : glm::vec2();
         if (secondUI == nullptr) {
             if (inventoryView) {
-                inventoryView->setPos(glm::vec2(
-                    glm::min(
+                if (compact) {
+                    inventoryView->setPos(glm::vec2(
                         viewport.x / 2 - invSize.x / 2,
-                        viewport.x - caWidth - 10 - invSize.x
-                    ),
-                    viewport.y / 2 - invSize.y / 2
-                ));
+                        viewport.y / 2 - invSize.y / 2
+                    ));
+                } else {
+                    inventoryView->setPos(glm::vec2(
+                        glm::min(
+                            viewport.x / 2 - invSize.x / 2,
+                            viewport.x - caWidth - 10 - invSize.x
+                        ),
+                        viewport.y / 2 - invSize.y / 2
+                    ));
+                }
             }
         } else {
             glm::vec2 secondUISize = secondUI->getSize();

--- a/src/frontend/hud.hpp
+++ b/src/frontend/hud.hpp
@@ -129,6 +129,10 @@ class Hud : public util::ObjectsKeeper {
 
     void processInput(bool visible);
     void updateElementsPosition(const glm::uvec2& viewport);
+
+    /// @brief Check if the viewport is too narrow to fit the inventory
+    /// and the content access panel side by side (small screens/windows)
+    bool isCompactMode(const glm::uvec2& viewport) const;
     void updateHotbarControl();
     void cleanup();
 

--- a/src/graphics/core/Atlas.cpp
+++ b/src/graphics/core/Atlas.cpp
@@ -70,7 +70,7 @@ std::unique_ptr<Atlas> AtlasBuilder::build(uint extrusion, bool prepare, uint ma
     if (maxResolution == 0) {
         maxResolution = Texture::MAX_RESOLUTION;
     }
-    auto sizes = std::make_unique<uint[]>(entries.size() * 2);
+    auto sizes = std::make_unique<uint32_t[]>(entries.size() * 2);
     uint index = 0;
     for (auto& entry : entries) {
         auto image = entry.image;

--- a/src/graphics/core/Batch2D.cpp
+++ b/src/graphics/core/Batch2D.cpp
@@ -1,7 +1,9 @@
 #include "Batch2D.hpp"
 #include "Mesh.hpp"
 #include "Texture.hpp"
+#ifndef VC_NO_GL
 #include "gl_util.hpp"
+#endif
 #include "maths/UVRegion.hpp"
 
 #include <cmath>
@@ -373,10 +375,16 @@ void Batch2D::flush() {
     if (index == 0)
         return;
     mesh->reload(buffer.get(), index);
+#ifdef VC_NO_GL
+    mesh->draw(static_cast<unsigned int>(primitive));
+#else
     mesh->draw(gl::to_glenum(primitive));
+#endif
     index = 0;
 }
 
 void Batch2D::lineWidth(float width) {
+#ifndef VC_NO_GL
     glLineWidth(width);
+#endif
 }

--- a/src/graphics/core/Mesh.hpp
+++ b/src/graphics/core/Mesh.hpp
@@ -63,4 +63,6 @@ public:
     void draw() const;
 };
 
+#ifndef VC_NO_GL
 #include "graphics/core/Mesh.inl"
+#endif

--- a/src/graphics/ui/GUI.cpp
+++ b/src/graphics/ui/GUI.cpp
@@ -293,14 +293,21 @@ void GUI::draw(const DrawContext& pctx, Assets& assets) {
     uicamera->setFov(viewport.y);
     uicamera->setAspectRatio(viewport.x / static_cast<float>(viewport.y));
 
+#ifndef VC_NO_GL
     auto uishader = assets.get<Shader>("ui");
     uishader->use();
     uishader->uniformMatrix("u_projview", uicamera->getProjView());
+#endif
 
     batch2D->begin();
     for (auto& [outputTexture, frame] : frames) {
+#ifdef VC_NO_GL
+        // no offscreen framebuffers: draw frame contents directly
+        frame->Container::draw(ctx, assets);
+#else
         frame->updateOutput(assets);
         frame->draw(ctx, assets);
+#endif
     }
 
     if (hover) {

--- a/src/graphics/ui/elements/InventoryView.cpp
+++ b/src/graphics/ui/elements/InventoryView.cpp
@@ -491,6 +491,12 @@ void SlotView::clicked(Mousecode button) {
     auto exchangeSlot =
         std::dynamic_pointer_cast<SlotView>(gui.get(EXCHANGE_SLOT_NAME));
     if (exchangeSlot == nullptr) {
+        // no exchange slot in this UI context; a slot items can't be
+        // taken from acts as a button, so a click still notifies
+        // updateFunc (used e.g. for tap-to-select hotbars)
+        if (!layout.taking && layout.updateFunc) {
+            layout.updateFunc(layout.index, *bound);
+        }
         return;
     }
     ItemStack& grabbed = exchangeSlot->getStack();

--- a/src/graphics/ui/elements/ModelViewer.cpp
+++ b/src/graphics/ui/elements/ModelViewer.cpp
@@ -14,7 +14,9 @@
 #include "../GUI.hpp"
 
 // TODO: remove
+#ifndef VC_NO_GL
 #include <GL/glew.h>
+#endif
 
 using namespace gui;
 
@@ -118,7 +120,9 @@ void ModelViewer::draw(const DrawContext& pctx, const Assets& assets) {
     
     fbo->resize(size.x, size.y);
     {
+#ifndef VC_NO_GL
         glDisable(GL_SCISSOR_TEST);
+#endif
         auto ctx = pctx.sub();
         ctx.setFramebuffer(fbo.get());
         ctx.setViewport({size.x, size.y});
@@ -142,7 +146,9 @@ void ModelViewer::draw(const DrawContext& pctx, const Assets& assets) {
             }
         }
         batch->flush();
+#ifndef VC_NO_GL
         glEnable(GL_SCISSOR_TEST);
+#endif
     }
 
     auto pos = calcPos();

--- a/src/io/settings_io.cpp
+++ b/src/io/settings_io.cpp
@@ -89,6 +89,7 @@ SettingsHandler::SettingsHandler(EngineSettings& settings) {
     builder.addSection("ui");
     builder.add("language", &settings.ui.language);
     builder.add("world-preview-size", &settings.ui.worldPreviewSize);
+    builder.add("hotbar-interactive", &settings.ui.hotbarInteractive);
 
     builder.addSection("pathfinding");
     builder.add("steps-per-async-agent", &settings.pathfinding.stepsPerAsyncAgent);

--- a/src/logic/scripting/lua/libs/lib__skeleton.cpp
+++ b/src/logic/scripting/lua/libs/lib__skeleton.cpp
@@ -26,6 +26,11 @@ static rigging::Skeleton* get_skeleton(lua::State* L) {
         return nullptr;
     }
     if (lua::isstring(L, 1)) {
+        // named skeletons live in the world renderer, which does not
+        // exist outside of a level or in builds without a renderer
+        if (scripting::renderer == nullptr) {
+            return nullptr;
+        }
         return scripting::renderer->skeletons->getSkeleton(lua::tostring(L, 1));
     }
     if (auto entity = get_entity(L, 1)) {

--- a/src/objects/Transform.hpp
+++ b/src/objects/Transform.hpp
@@ -3,6 +3,7 @@
 #define GLM_ENABLE_EXPERIMENTAL
 
 #include <stdexcept>
+#include <string_view>
 #include <glm/vec3.hpp>
 #include <glm/mat4x4.hpp>
 #include <glm/gtx/norm.hpp>

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -117,6 +117,9 @@ struct DebugSettings {
 struct UiSettings {
     StringSetting language {"auto"};
     IntegerSetting worldPreviewSize {64, 1, 512};
+    /// @brief Select hotbar slots by clicking/tapping them
+    /// (intended for touch screens)
+    FlagSetting hotbarInteractive {false};
 };
 
 struct NetworkSettings {

--- a/src/voxels/Chunks.cpp
+++ b/src/voxels/Chunks.cpp
@@ -158,7 +158,7 @@ Chunk* Chunks::getChunkByVoxel(int32_t x, int32_t y, int32_t z) const {
     return nullptr;
 }
 
-Chunk* Chunks::getChunk(int x, int z) const {
+Chunk* Chunks::getChunk(int32_t x, int32_t z) const {
     if (auto ptr = areaMap.getIf(x, z)) {
         return ptr->get();
     }

--- a/src/voxels/GlobalChunks.cpp
+++ b/src/voxels/GlobalChunks.cpp
@@ -90,7 +90,13 @@ static inline auto load_inventories(
     return invs;
 }
 
-static util::ObjectsPool<Chunk> chunks_pool(1'024);
+// Number of preallocated chunks. Overridable at build time: on
+// memory-constrained platforms preallocation may cost more RAM than the
+// platform has (pool size * sizeof(Chunk)); 0 makes allocation fully lazy.
+#ifndef VC_CHUNKS_POOL_SIZE
+#define VC_CHUNKS_POOL_SIZE 1'024
+#endif
+static util::ObjectsPool<Chunk> chunks_pool(VC_CHUNKS_POOL_SIZE);
 static util::ObjectsPool<Lightmap> lightmaps_pool;
 
 std::shared_ptr<Chunk> GlobalChunks::create(int x, int z, bool lighting) {

--- a/src/world/files/WorldRegions.cpp
+++ b/src/world/files/WorldRegions.cpp
@@ -184,7 +184,7 @@ void WorldRegions::put(Chunk* chunk, std::vector<ubyte> entitiesData) {
     }
     // Writing block inventories
     if (!chunk->inventories.empty() || chunk->flags.inventoriesRemoved) {
-        uint datasize;
+        uint32_t datasize;
         auto data = write_inventories(chunk->inventories, datasize);
         put(chunk->x,
             chunk->z,


### PR DESCRIPTION
Hi! I've been porting VoxelCore to the old Nintendo 3DS (ARM11, 128 MB RAM, no OpenGL, no OpenAL, LuaJIT with a non-working FFI). The port itself lives out of tree in my fork, but while getting the engine to run on that hardware I ran into a few real bugs and a number of places where a small change makes the core much easier to reuse on weak or unusual platforms. This PR is exactly those changes and nothing 3DS-specific: all defaults are untouched, a regular desktop build compiles the same code paths as before.

**Bug fixes**

- `gzip::decompress` read the uncompressed size from the gzip footer by casting an unaligned pointer to `const uint32_t*`. That's UB, and on strict-alignment ARM the load comes back rotated, so the output buffer gets resized to a garbage value. Now the field is read byte by byte. This one cost me a lot of debugging time on device.
- `lib__skeleton` dereferenced `scripting::renderer` without a null check. It is null until the HUD is initialized and after the level closes, so calling skeleton functions by name in that window crashes on desktop too.
- `Hud::openInventory` crashed if the `core:inventory` document is missing from assets (stripped resources / custom builds).
- `fs::canonical` in EnginePaths startup logging throws if a folder doesn't exist yet (they are created a couple of lines later); replaced with `weakly_canonical`, same output for existing paths.
- `Transform.hpp` uses `std::string_view` without including it - breaks on stdlibs where it isn't pulled in transitively (newlib).
- A few call sites passed `uint`/`int` into interfaces declared with `uint32_t`/`int32_t` (LMPacker, write_inventories, Chunks::getChunk definition vs declaration). Fails to compile on toolchains where `uint32_t` is `unsigned long` (newlib again).

**Portability**

- Lua: removed the goto-continue patterns from four core scripts. `goto` doesn't exist in Lua 5.1 (LuaJIT extension), and these scripts were the only thing preventing the core scripting stack from running on a plain 5.1 interpreter. No behavior changes. Along the way dropped a `j = j - 3` inside a numeric for - assigning the control variable is a no-op in Lua, so the line did nothing anyway (and is a compile error since 5.4).
- Lua: made the FFI optional. The scripts now probe ffi once with a malloc/free round-trip and fall back cleanly when it's missing or non-functional: a pure-Lua Bytearray/typed-views implementation (`bytearray_fallback.lua`), `os.pid = 0`, crc32 through `string.char`, named pipes report "unavailable" instead of crashing on load. On LuaJIT with a working FFI nothing changes. Fun fact from the port: on a statically linked homebrew binary LuaJIT itself works fine, but `ffi.C` can't resolve a single symbol.
- `VC_NO_GL`: compiles out the direct OpenGL usage from the otherwise platform-independent UI/HUD layer (Batch2D internals, the Mesh.inl include, ModelViewer scissor toggles, the builtin "ui" shader setup, BlocksPreview generation). With this a port can provide its own Mesh/Texture/Shader implementations and reuse the entire GUI stack unchanged - that's how the whole engine GUI runs on the 3DS bottom screen.
- `VC_NO_AL` + `VC_AUDIO_CUSTOM_BACKEND`: audio is already abstracted behind `audio::Backend`, but `initialize()` hardcoded ALAudio. Now the AL backend can be compiled out and a port can plug a native one through `audio::create_custom_backend()` (NDSP in my case). NoAudio remains the fallback.
- `VC_CHUNK_H`, `VC_ITEM_ICON_SIZE`, `VC_CHUNKS_POOL_SIZE`: build-time overrides for the constants that dominate memory usage on small devices, all defaulting to the current values (default builds are bit-identical). On the 3DS, preallocating 1024 chunks simply doesn't fit in RAM, and CHUNK_H=128 is the difference between running and OOM. The chunk-height comment documents that worlds aren't portable across different values.

**UI on small screens**

- When the viewport is too narrow to fit the player inventory next to the content-access panel, they are now shown one at a time, centered, instead of overlapping. The mode is derived from the actual element sizes at runtime, so a small desktop window gets the same fix.
- New `ui.hotbar-interactive` setting (off by default): clicking/tapping a hotbar slot selects it. Written for the touch screen, works anywhere. To support it, slots with `taking = false` now notify `updateFunc` on click when no exchange slot exists in the UI context - previously such clicks were silently dropped.

Everything is split into self-contained commits with the reasoning in the commit messages. Line endings of the CRLF files are preserved, so the diffs are minimal. Tested on the 3DS build (devkitARM; verified in Azahar and on hardware) and the desktop paths of the touched files. If you'd prefer to take only part of this, or want it split into several smaller PRs (fixes / Lua / build knobs / UI) - happy to do that.
