### PR TITLE
fix clock.cpp

### DIFF
--- a/src/util/Clock.cpp
+++ b/src/util/Clock.cpp
@@ -1,6 +1,5 @@
 #include "Clock.hpp"
 
-#include <cmath>
 #include <algorithm>
 
 using namespace util;
@@ -20,10 +19,8 @@ int Clock::update(float delta) {
         tickTimer -= parts * delay / tickParts;
         tickTimer = std::min<float>(tickTimer, delay);
     }
-    currentTickPart += parts;
-    if (currentTickPart >= tickParts) {
-        currentTickPart %= tickParts;
-    }
+    lastPartsStart = currentTickPart;
+    currentTickPart = (currentTickPart + parts) % tickParts;
     return parts;
 }
 
@@ -40,5 +37,5 @@ int Clock::getTickId() const {
 }
 
 int Clock::convertPart(int index) const {
-    return (tickParts - currentTickPart) % tickParts + index;
+    return (lastPartsStart + index) % tickParts;
 }

--- a/src/util/Clock.hpp
+++ b/src/util/Clock.hpp
@@ -8,6 +8,7 @@ namespace util {
         float tickTimer = 0.0f;
         int tickId = 0;
         int currentTickPart = 0;
+        int lastPartsStart = 0;
     public:
         Clock(int tickRate, int tickParts);
 


### PR DESCRIPTION
Данный pr является фиксом [этого](https://discord.com/channels/662649594454343691/1499499716239425566/1536688716909641758) бага, ну, а так же возможно и других

Раньше convertPart() мог вернуть невалидное число, что ломало on_update

```lua
update = function(tps, parts, part)
    for uid, entity in pairs(entities) do
        if uid % parts ~= part then -- Здесь просто вызывался continue
            goto continue
        end
```

Движок раньше сначала передвигал указатель на part вперёд, а потом уже из сдвинутого положения вычислял, какие номера обрабатывать, что приводило к ошибкам

в фиксе я поменял порядок (сначала запомнили, потом сдвинули currentTickPart) + ещё поменял формулу так, чтобы он не выходил за tickParts

ну и \<cmath> бесполезный убрал