### PR TITLE
add mul* functions to quats & fix to_string

### DIFF
--- a/src/logic/scripting/lua/libs/libquat.cpp
+++ b/src/logic/scripting/lua/libs/libquat.cpp
@@ -35,7 +35,7 @@ static int l_tostring(lua::State* L) {
 
     float components[4] = {quat.w, quat.x, quat.y, quat.z};
     std::stringstream ss;
-    ss << "quat" << "{";
+    ss << "quat {";
     for (int i = 0; i < 4; i++) {
         if (i > 0) {
             ss << ", ";

--- a/src/logic/scripting/lua/libs/libquat.cpp
+++ b/src/logic/scripting/lua/libs/libquat.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+#include <glm/gtx/string_cast.hpp> 
 #include "api_lua.hpp"
 
 #define GLM_ENABLE_EXPERIMENTAL
@@ -31,14 +33,14 @@ static int l_tostring(lua::State* L) {
     lua::check_argc(L, 1);
     auto quat = lua::toquat(L, 1);
 
+    float components[4] = {quat.w, quat.x, quat.y, quat.z};
     std::stringstream ss;
-    ss << "quat"
-       << "{";
+    ss << "quat" << "{";
     for (int i = 0; i < 4; i++) {
         if (i > 0) {
             ss << ", ";
         }
-        ss << quat[i];
+        ss << components[i];
     }
     ss << "}";
     return lua::pushstring(L, ss.str());
@@ -52,10 +54,42 @@ static int l_from_euler(lua::State *L) {
     return lua::pushquat(L, glm::quat(euler));
 }
 
+static int l_mul(lua::State* L) {
+    uint argc = lua::check_argc(L, 2, 3);
+    glm::quat a = lua::toquat(L, 1);
+    glm::quat b = lua::toquat(L, 2);
+    
+    glm::quat result = a * b;
+    
+    if (argc == 3) {
+        lua::setquat(L, 3, result);
+        return 0;
+    }
+    
+    return lua::pushquat(L, result);
+}
+
+static int l_mul_vec3(lua::State* L) {
+    uint argc = lua::check_argc(L, 2, 3);
+    glm::quat q = lua::toquat(L, 1);
+    glm::vec3 v = lua::tovec3(L, 2);
+
+    glm::vec3 result = q * v;
+    
+    if (argc == 3) {
+        lua::setvec(L, 3, result);
+        return 0;
+    }
+    
+    return lua::pushvec3(L, result);
+}
+
 const luaL_Reg quatlib[] = {
     {"from_mat4", lua::wrap<l_from_mat4>},
     {"from_euler", lua::wrap<l_from_euler>},
     {"slerp", lua::wrap<l_slerp>},
     {"tostring", lua::wrap<l_tostring>},
+    {"mul", lua::wrap<l_mul>},
+    {"mul_vec3", lua::wrap<l_mul_vec3>},
     {nullptr, nullptr}
 };

--- a/src/logic/scripting/lua/libs/libquat.cpp
+++ b/src/logic/scripting/lua/libs/libquat.cpp
@@ -1,8 +1,8 @@
+#define GLM_ENABLE_EXPERIMENTAL
 #include <iostream>
 #include <glm/gtx/string_cast.hpp> 
 #include "api_lua.hpp"
 
-#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/ext/matrix_transform.hpp>
 #include <glm/gtx/quaternion.hpp>
 #include <sstream>


### PR DESCRIPTION
Добавлены функции умножения кватернионов и исправлена функция to_string,
потому что надо отображать поля в таком порядке: w,x,y,z
Так как если сделать например умножение:
local q = quat.mul({1,0,0,0}, {1,0,0,0})
debug.print(quat.to_string(q))

То выводилось бы (раньше) quat{0, 0, 0, 1}, что, очевидно, неправильно