### PR TITLE
Fix drop from slot

### DIFF
--- a/res/content/base/modules/util.lua
+++ b/res/content/base/modules/util.lua
@@ -1,26 +1,22 @@
 local util = {}
 
-local DROP_FORCE = 8
-local DROP_INIT_VEL = { 0, 3, 0 }
-local DROP_MAX_ITEM_DIR_SHIFT_DEGREES = 65
+util.DROP_FORCE = 8
+util.DROP_INIT_VEL = { 0, 3, 0 }
+util.DROP_MAX_ITEM_DIR_SHIFT_DEGREES = 65
 
-local function calculate_item_drop_dir(pid)
-    local yaw, pitch = player.get_rot(pid)
-    local vp = gui.get_viewport()
-    local mpos = table.map(input.get_mouse_pos(), function(i, v)
-        return v / vp[i] - 0.5
-    end)
-    if not hud.is_inventory_open() and not hud.is_player_inventory_open() then
-        mpos = { 0, 0 }
+---@param dir_shift? vec2 direction shift for drop; x and y must be clamped to [-0.5, 0.5]
+local function calculate_item_drop_dir(pid, dir_shift)
+    if not dir_shift then
+        dir_shift = { 0, 0 }
     end
-
+    local yaw, pitch = player.get_rot(pid)
     local q_yaw = quat.from_euler({ 0, yaw, 0 })
     local q_pitch = quat.from_euler({ pitch, 0, 0 })
     local q_rotation = quat.mul(q_yaw, q_pitch)
 
     local q_shift = quat.from_euler({
-        -mpos[2] * DROP_MAX_ITEM_DIR_SHIFT_DEGREES * 2,
-        -mpos[1] * DROP_MAX_ITEM_DIR_SHIFT_DEGREES * 2,
+        -dir_shift[2] * util.DROP_MAX_ITEM_DIR_SHIFT_DEGREES * 2,
+        -dir_shift[1] * util.DROP_MAX_ITEM_DIR_SHIFT_DEGREES * 2,
         0,
     })
     quat.mul(q_rotation, q_shift, q_rotation)
@@ -29,8 +25,9 @@ end
 
 --- Create a drop from slot, set it velocity, and return it
 ---@param mode integer 0 - whole stack, 1 - single item, 2 - dupe whole stack
+---@param dir_shift? vec2 direction shift for drop; x and y must be clamped to [-0.5, 0.5]
 ---@return table? entity, string? error
-function util.drop_from_slot(pid, invid, slot, mode)
+function util.drop_from_slot(pid, invid, slot, mode, dir_shift)
     if invid == 0 then
         return nil, "invid cannot be 0"
     end
@@ -55,13 +52,13 @@ function util.drop_from_slot(pid, invid, slot, mode)
     local data = inventory.get_all_data(invid, slot)
     local pvel = { player.get_vel(pid) }
     local ppos = vec3.add({ player.get_pos(pid) }, { 0, 0.7, 0 })
-    local dir = calculate_item_drop_dir(pid)
-    local throw_force = vec3.mul(dir, DROP_FORCE)
+    local dir = calculate_item_drop_dir(pid, dir_shift)
+    local throw_force = vec3.mul(dir, util.DROP_FORCE)
     local drop, err = util.drop(ppos, itemid, drop_itemcount, data, 1.5)
     if not drop then
         return nil, err
     end
-    local velocity = vec3.add(throw_force, vec3.add(pvel, DROP_INIT_VEL))
+    local velocity = vec3.add(throw_force, vec3.add(pvel, util.DROP_INIT_VEL))
     drop.rigidbody:set_vel(velocity)
     return drop
 end

--- a/res/content/base/modules/util.lua
+++ b/res/content/base/modules/util.lua
@@ -1,20 +1,21 @@
 local util = {}
 
 local DROP_FORCE = 8
-local DROP_INIT_VEL = {0, 3, 0}
+local DROP_INIT_VEL = { 0, 3, 0 }
 
+--- Create a drop from slot, set it velocity, and return it
 ---@param mode integer 0 - whole stack, 1 - single item, 2 - dupe whole stack
-function util.drop_from_slot(invid, slot, mode)
+---@return table? entity, string? error
+function util.drop_from_slot(pid, invid, slot, mode)
     if invid == 0 then
-        return
+        return nil, "invid cannot be 0"
     end
-    local pid = hud.get_player()
     if mode == 2 and not player.is_infinite_items(pid) then
-        return
+        return nil, "no permission to dupe items"
     end
     local itemid, itemcount = inventory.get(invid, slot)
     if itemid == 0 then
-        return
+        return nil, "no item in slot"
     end
 
     local drop_itemcount = 1
@@ -31,24 +32,28 @@ function util.drop_from_slot(invid, slot, mode)
     local pvel = { player.get_vel(pid) }
     local ppos = vec3.add({ player.get_pos(pid) }, { 0, 0.7, 0 })
     local throw_force = vec3.mul(player.get_dir(pid), DROP_FORCE)
-    local drop = util.drop(ppos, itemid, drop_itemcount, data, 1.5)
+    local drop, err = util.drop(ppos, itemid, drop_itemcount, data, 1.5)
     if not drop then
-        return
+        return nil, err
     end
     local velocity = vec3.add(throw_force, vec3.add(pvel, DROP_INIT_VEL))
     drop.rigidbody:set_vel(velocity)
+    return drop
 end
 
+---@return table? entity, string? error
 function util.drop(ppos, itemid, count, data, pickup_delay)
     if itemid == 0 or not itemid then
-        return nil
+        return nil, "item is empty"
     end
-    return entities.spawn("base:drop", ppos, {base__drop={
-        id=itemid,
-        count=count,
-        data=data,
-        pickup_delay=pickup_delay
-    }})
+    return entities.spawn("base:drop", ppos, {
+        base__drop = {
+            id = itemid,
+            count = count,
+            data = data,
+            pickup_delay = pickup_delay
+        }
+    })
 end
 
 function util.calc_loot(loot_table)
@@ -66,7 +71,9 @@ function util.calc_loot(loot_table)
             if count == 0 then
                 goto continue
             end
-            table.insert(results, {item=item.index(loot.item), count=count})
+            table.insert(results, {
+                item = item.index(loot.item), count = count
+            })
         end
         ::continue::
     end
@@ -78,7 +85,7 @@ function util.block_loot(blockid)
     if lootscheme then
         return util.calc_loot(lootscheme)
     end
-    return {{item=block.get_picking_item(blockid), count=1}}
+    return { { item = block.get_picking_item(blockid), count = 1 } }
 end
 
 return util

--- a/res/content/base/scripts/hud.lua
+++ b/res/content/base/scripts/hud.lua
@@ -4,7 +4,11 @@ function on_hud_open()
     events.on("core:drop_outside_inventory", function(mode)
         local pid = hud.get_player()
         local invid = hud.get_exchange_inventory()
-        base_util.drop_from_slot(pid, invid, 0, mode)
+        local vp = gui.get_viewport()
+        local dir_shift = table.map(input.get_mouse_pos(), function(i, v)
+            return v / vp[i] - 0.5
+        end)
+        base_util.drop_from_slot(pid, invid, 0, mode, dir_shift)
     end)
     input.add_callback("player.drop", function()
         if hud.is_paused() or hud.is_inventory_open() then

--- a/res/content/base/scripts/hud.lua
+++ b/res/content/base/scripts/hud.lua
@@ -2,8 +2,9 @@ local base_util = require "util"
 
 function on_hud_open()
     events.on("core:drop_outside_inventory", function(mode)
+        local pid = hud.get_player()
         local invid = hud.get_exchange_inventory()
-        base_util.drop_from_slot(invid, 0, mode)
+        base_util.drop_from_slot(pid, invid, 0, mode)
     end)
     input.add_callback("player.drop", function()
         if hud.is_paused() or hud.is_inventory_open() then
@@ -13,9 +14,9 @@ function on_hud_open()
         local invid, slot = player.get_inventory(pid)
         local mode = 1
         if input.is_pressed("key:left-ctrl") or input.is_pressed("key:right-ctrl") then
-          mode = 0
+            mode = 0
         end
-        base_util.drop_from_slot(invid, slot, mode)
+        base_util.drop_from_slot(pid, invid, slot, mode)
     end)
     rules.create("do-loot-non-player", true)
 end


### PR DESCRIPTION
в коде base:util был hud, который мешал работе мультиплеера, да и по логике не обязан там быть.
Теперь сторону, в которую предмет должен полететь мы вычисляем в hud.lua, 
а также игрока - hud.get_player(). 

Также значения типа DROP_FORCE вынесены из локальной области в модуль, чтобы паки могли их переопределять.