### PR TITLE
Move sensors clearing to the top

### DIFF
--- a/src/objects/Entities.cpp
+++ b/src/objects/Entities.cpp
@@ -295,14 +295,13 @@ void Entities::preparePhysics(float delta) {
     auto& physics = *level.physics;
     auto& hitboxes = physics.getHitboxesWriteable();
     auto& solidHitboxes = physics.getSolidHitboxesWriteable();
+    auto& sensors = physics.getSensorsWriteable();
+    sensors.clear();
 
     if (int parts = sensorsTickClock.update(delta)) {
         for (int i = 0; i < parts; i++) {
             auto part = sensorsTickClock.convertPart(i);
             auto allParts = sensorsTickClock.getParts();
-
-            auto& sensors = physics.getSensorsWriteable();
-            sensors.clear();
 
             auto view = registry->view<EntityId, Transform, Rigidbody>();
             for (auto [entity, eid, transform, rigidbody] : view.each()) {


### PR DESCRIPTION
В мультиплеере (neutron) не сразу поднимались предметы. Этот фикс исправляет проблему.

Ну и по логике, physics.getSensorsWriteable() же не меняется при повторном вызове внутри цикла, зачем его вызывать несколько раз? Вынесем его наверх.

В одиночной игре предметы поднимаются отлично, как и раньше (я проверял)